### PR TITLE
chain to the codeql submodule's manifest instead of replicating it

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -1,7 +1,2 @@
-{ "provide": [ "codeql/codeql-queries/*/ql/src/qlpack.yml",
-               "codeql/codeql-queries/*/ql/test/qlpack.yml",
-               "codeql/codeql-queries/*/ql/examples/qlpack.yml",
-               "codeql/codeql-queries/*/upgrades/qlpack.yml",
-               "codeql/codeql-queries/misc/legacy-support/*/qlpack.yml",
-               "codeql/codeql-queries/misc/suite-helpers/qlpack.yml",
+{ "provide": [ "codeql/codeql-queries/.codeqlmanifest.json",
                "codeql/windows-drivers/qlpack.yml"] }


### PR DESCRIPTION
`.codeqlmanifest.json` can chain to a `.codeqlmanifest.json` in a subdirectory.

This way you don't need to copy-paste the contents of the manifest from the codeql/codeql-queries subdmodule, making it easier to stay in sync with its content.