### PR TITLE
Remove uninitialized local check from must-fix due to high noise.

### DIFF
--- a/codeql/windows-drivers/suites/windows_driver_mustfix.qls
+++ b/codeql/windows-drivers/suites/windows_driver_mustfix.qls
@@ -7,7 +7,6 @@
     query path: 
       - Likely Bugs/Arithmetic/BadAdditionOverflowCheck.ql
       - Likely Bugs/Memory Management/PointerOverflow.ql
-      - Likely Bugs/Memory Management/UninitializedLocal.ql
       - Likely Bugs/Underspecified Functions/TooFewArguments.ql
       - Security/CWE/CWE-190/ComparisonWithWiderType.ql
       - Security/CWE/CWE-253/HResultBooleanConversion.ql


### PR DESCRIPTION
The "Likely Bugs/Memory Management/UninitializedLocal.ql" query is showing too many false positives at the moment, and so we are moving it from must-fix to recommended.