### PR TITLE
Add build action for the CodeQL queries in the recommended suite.

### DIFF
--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -1,8 +1,8 @@
-# This is a basic workflow to help you get started with Actions
+# Continuous integration action for the CodeQL components of this repo.
+# This downloads the CodeQL CLI and then builds all the queries in the "windows_driver_recommended.qls" suite.
 
-name: CI
+name: Build live CodeQL queries
 
-# Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -10,19 +10,17 @@ on:
   pull_request:
     branches: [ main ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allow manual scheduling
   workflow_dispatch:
-
 
 jobs:
   build:
     runs-on: windows-latest
 
     steps:
-    - name: Set Git environment
+    - name: Enable long git paths
       shell: cmd
       run: git config --global core.longpaths true
-        
     - name: Clone self (windows-driver-developer-supplemental-tools)
       uses: actions/checkout@v2
       with:
@@ -36,8 +34,7 @@ jobs:
         tag: "latest"
         file: "codeql-win64.zip"
     - name: Unzip CodeQL CLI
-      shell: cmd
-      run: powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('codeql-win64.zip', '.'); }"
+      run: Expand-Archive -Path codeql-win64.zip -DestinationPath . -Force
     - name: Test build
       shell: cmd
       run: .\codeql\codeql.cmd query compile --check-only windows_driver_recommended.qls

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -1,7 +1,7 @@
 # Continuous integration action for the CodeQL components of this repo.
 # This downloads the CodeQL CLI and then builds all the queries in the "windows_driver_recommended.qls" suite.
 
-name: Build live CodeQL queries
+name: Build recommended CodeQL queries
 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -35,6 +35,6 @@ jobs:
         file: "codeql-win64.zip"
     - name: Unzip CodeQL CLI
       run: Expand-Archive -Path codeql-win64.zip -DestinationPath . -Force
-    - name: Test build
+    - name: Build recommended query suite
       shell: cmd
       run: .\codeql\codeql.cmd query compile --check-only windows_driver_recommended.qls

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -18,6 +18,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Get cached CLI
+      uses: actions/cache@v2
+      id: cli-cache
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: .\codeql
+        key: codeql-cli-v2.5.0
     - name: Enable long git paths
       shell: cmd
       run: git config --global core.longpaths true
@@ -27,13 +35,15 @@ jobs:
         path: windows-driver-developer-supplemental-tools
         submodules: recursive
     - name: Download CodeQL CLI
+      if: steps.cli-cache.outputs.cache-hit != 'true'
       uses: i3h/download-release-asset@v1.2.0
       with:
         owner: "github"
         repo: "codeql-cli-binaries"
-        tag: "latest"
+        tag: "v2.5.0"
         file: "codeql-win64.zip"
     - name: Unzip CodeQL CLI
+      if: steps.cli-cache.outputs.cache-hit != 'true'
       run: Expand-Archive -Path codeql-win64.zip -DestinationPath . -Force
     - name: Build recommended query suite
       shell: cmd

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Set Git environment
+      shell: cmd
+      run: git config --global core.longpaths true
+        
+    - name: Clone self (windows-driver-developer-supplemental-tools)
+      uses: actions/checkout@v2
+      with:
+        path: windows-driver-developer-supplemental-tools
+        submodules: recursive
+    - name: Download CodeQL CLI
+      uses: i3h/download-release-asset@v1.2.0
+      with:
+        owner: "github"
+        repo: "codeql-cli-binaries"
+        tag: "latest"
+        file: "codeql-win64.zip"
+    - name: Unzip CodeQL CLI
+      shell: cmd
+      run: powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('codeql-win64.zip', '.'); }"
+    - name: Test build
+      shell: cmd
+      run: .\codeql\codeql.cmd query compile --check-only windows_driver_recommended.qls


### PR DESCRIPTION
This PR creates a GitHub action that builds all CodeQL queries in the windows_driver_recommended.qls suite, which covers all queries we are currently officially supporting to be run as part of certification.

This action attempts to clone this repo and its submodules, fetch v2.5.0 of the CodeQL CLI, and then run codeql-compile on the aforementioned suite.