### PR TITLE
Add missing copyright headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # query compilation caches
 */codeql/**/*.cache
+codeql/**/*.cache

--- a/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/InformationLeakBoundaries.qll
+++ b/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/InformationLeakBoundaries.qll
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Provides the class `InformationLeakBoundary`, which models data-flow sinks
  * where information is passed across a trust boundary.

--- a/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosure.ql
+++ b/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosure.ql
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @name Possible information leakage from uninitialized padding bytes.
  * @description A newly allocated struct or class that is initialized member-by-member may

--- a/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosureBadCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosureBadCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 typedef enum { Unknown = 0, Known = 1, Other = 2 } MyStructType;
 struct MyStruct { MyStructType type; UINT64 id; };
 

--- a/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosureGoodCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosureGoodCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 typedef enum { Unknown = 0, Known = 1, Other = 2 } MyStructType;
 struct MyStruct { MyStructType type; UINT64 id; };
 

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuard.ql
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuard.ql
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @name Bad overflow check
  * @description Checking for overflow of an addition by comparing against one

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuardBadCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuardBadCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 unsigned short CheckForInt16OverflowBadCode(unsigned short v, unsigned short b)
 {
     if (v + b < v) // BUG: "v + b" will be promoted to 32 bits

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuardGoodCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/BadOverflowGuardGoodCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 unsigned short CheckForInt16OverflowCorrectCode(unsigned short v, unsigned short b)
 {
     if (v + b > 0x00FFFF)

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoop.ql
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoop.ql
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @name Comparison of narrow type with wide type in loop condition
  * @description Comparisons between types of different widths in a loop

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoopBadCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoopBadCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 void InfiniteLoop(int a)
 {
     for (short i = 0; i < a; i++) // BUG: infinite loop

--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoopGoodCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoopGoodCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 void NotInfiniteLoop(int a)
 {
     for (int i = 0; i < a; i++) 

--- a/codeql/windows-drivers/queries/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree_bad.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree_bad.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 NTSTATUS Status = x();
 
 if (Status != 0)

--- a/codeql/windows-drivers/queries/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree_good.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree_good.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 NTSTATUS Status = x();
 
 if (Status != 0)

--- a/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrField.ql
+++ b/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrField.ql
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @name Dereference of potentially uninitialized pointer field
  * @description A pointer field which was not initialized during or since class 

--- a/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrFieldBadCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrFieldBadCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 template <typename T>
 class ComPtr
 {

--- a/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrFieldGoodCode.c
+++ b/codeql/windows-drivers/queries/Likely Bugs/UninitializedPtrFieldGoodCode.c
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 template <typename T>
 class ComPtr
 {

--- a/codeql/windows-drivers/queries/Security/Crytpography/HardcodedIVCNG.ql
+++ b/codeql/windows-drivers/queries/Security/Crytpography/HardcodedIVCNG.ql
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * @name Weak cryptography
  * @description Finds usage of a static (hardcoded) IV. (CNG)

--- a/codeql/windows-drivers/queries/microsoft/code/cpp/commons/Literals.qll
+++ b/codeql/windows-drivers/queries/microsoft/code/cpp/commons/Literals.qll
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Provides classes and predicates for identifying variables and expression that have a static
  * value.

--- a/codeql/windows-drivers/queries/microsoft/code/cpp/commons/MemoryAllocation.qll
+++ b/codeql/windows-drivers/queries/microsoft/code/cpp/commons/MemoryAllocation.qll
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 /**
  * Provides classes for identifying expressions that allocate memory.
  */


### PR DESCRIPTION
Add copyright headers to the recently added recommended queries and libraries.