### PR TITLE
Update build-codeql.yaml

### DIFF
--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -39,9 +39,12 @@ jobs:
       shell: cmd
       continue-on-error: true # Required because robocopy returns 1 on success
       run: robocopy /S /move .\codeql-zip\codeql .\codeql-cli\
-    - name: Build all Windows queries
+    - name: Build must-fix driver suite
       shell: cmd
-      run: .\codeql-cli\codeql.cmd query compile --check-only .\codeql\windows-drivers
+      run: .\codeql-cli\codeql.cmd query compile --check-only .\codeql\windows-drivers\suites\windows_driver_mustfix.qls
     - name: Build recommended driver suite
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only .\codeql\windows-drivers\suites\windows_driver_recommended.qls
+    - name: Build all Windows queries
+      shell: cmd
+      run: .\codeql-cli\codeql.cmd query compile --check-only .\codeql\windows-drivers


### PR DESCRIPTION
Ensure we build both our suites, not just recommended, to catch any errors in suite consistency.