### PR TITLE
Address warnings about missing `override`

### DIFF
--- a/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoop.ql
+++ b/codeql/windows-drivers/queries/Likely Bugs/Conversion/InfiniteLoop.ql
@@ -20,7 +20,7 @@ import cpp
 import microsoft.code.cpp.commons.Literals
 
 class ReferenceFix extends ReferenceType {
-	int getSize() { result = this.getBaseType().getSize() }
+	override int getSize() { result = this.getBaseType().getSize() }
 }
 
 /**

--- a/codeql/windows-drivers/queries/microsoft/code/cpp/commons/MemoryAllocation.qll
+++ b/codeql/windows-drivers/queries/microsoft/code/cpp/commons/MemoryAllocation.qll
@@ -36,7 +36,7 @@ abstract class HeapAllocation extends Allocation, FunctionCall {
 	 * Gets the expression representing the allocation size in this call.
 	 */
 	abstract Expr getAllocatedSize();
-	string toString() { result = FunctionCall.super.toString() }
+	override string toString() { result = FunctionCall.super.toString() }
 }
 
 /**


### PR DESCRIPTION
When running `codeql database analyze` following the https://docs.microsoft.com/sl-si/windows-hardware/drivers/devtest/static-tools-and-codeql, we hit the following warnings:

```
  Compiling query plan for C:\Users\Simon\Projekti\wireguard-nt\Release\amd64\wddst\codeql\windows-drivers\queries\Likely Bugs\Conversion\InfiniteLoop.ql.
EXEC : warning : This predicate overrides another predicate but is not marked as 'override' (C:\Users\Simon\Projekti\wireguard-nt\Release\amd64\wddst\codeql\windows-drivers\queries\microsoft\code\cpp\commons\MemoryAllocation.qll:39,2-62) [C:\Users\Simon\Projekti\wiregua
rd-nt\wireguard-nt.proj]
  [21/26 comp 3s] Compiled C:\Users\Simon\Projekti\wireguard-nt\Release\amd64\wddst\codeql\windows-drivers\queries\Likely Bugs\Conversion\BadOverflowGuard.ql.
  Compiling query plan for C:\Users\Simon\Projekti\wireguard-nt\Release\amd64\wddst\codeql\windows-drivers\queries\Likely Bugs\Memory Management\UseAfterFree\UseAfterFree.ql.
EXEC : warning : This predicate overrides another predicate but is not marked as 'override' (C:\Users\Simon\Projekti\wireguard-nt\Release\amd64\wddst\codeql\windows-drivers\queries\Likely Bugs\Conversion\InfiniteLoop.ql:23,2-57) [C:\Users\Simon\Projekti\wireguard-nt\wir
eguard-nt.proj]
```

This PR silences the warnings.