### PR TITLE
Fix detection of WDM typedefs

### DIFF
--- a/src/drivers/wdm/libraries/WdmDrivers.qll
+++ b/src/drivers/wdm/libraries/WdmDrivers.qll
@@ -6,12 +6,20 @@ import drivers.libraries.SAL
 /** A typedef for the standard WDM callback routines. */
 class WdmCallbackRoutineTypedef extends TypedefType {
   WdmCallbackRoutineTypedef() {
-    this.getName().matches("DRIVER_UNLOAD") or
-    this.getName().matches("DRIVER_DISPATCH") or
-    this.getName().matches("DRIVER_INITIALIZE") or
-    this.getName().matches("IO_COMPLETION_ROUTINE") or
-    this.getName().matches("KSERVICE_ROUTINE") or
-    this.getName().matches("IO_DPC_ROUTINE")
+    (
+      this.getName().matches("DRIVER_UNLOAD")
+      or
+      this.getName().matches("DRIVER_DISPATCH")
+      or
+      this.getName().matches("DRIVER_INITIALIZE")
+      or
+      this.getName().matches("IO_COMPLETION_ROUTINE")
+      or
+      this.getName().matches("KSERVICE_ROUTINE")
+      or
+      this.getName().matches("IO_DPC_ROUTINE")
+    ) and
+    this.getFile().getBaseName().matches("%wdm.h")
   }
 }
 
@@ -29,8 +37,7 @@ class WdmCallbackRoutine extends Function {
   WdmCallbackRoutine() {
     exists(FunctionDeclarationEntry fde |
       fde.getFunction() = this and
-      fde.getTypedefType() = callbackType and
-      fde.getFile().getAnIncludedFile().getBaseName().matches("%wdm.h")
+      fde.getTypedefType() = callbackType
     )
   }
 }


### PR DESCRIPTION
The WDM library was detecting if a function was a WDM callback routine by checking if:

- The function typedef matched a set of WDM typedef names, and
- The function definition was in a file that imported wdm.h.

Thus in the case where a function was declared in the same file as its definition, and not in a separate header file that included wdm.h, the function would be incorrectly marked as not a WDM callback.

This change updates the logic so that the detection is based on if the typedef itself is defined in wdm.h.