### PR TITLE
Fixing a FP pattern for PUCHAR casting

### DIFF
--- a/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversion.cpp
+++ b/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversion.cpp
@@ -1,0 +1,3 @@
+wchar_t* pSrc;
+
+pSrc = (wchar_t*)"a"; // casting a byte-string literal "a" to a wide-character string

--- a/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.qhelp
+++ b/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+  <p>This rule indicates a potentially incorrect cast from an byte string (<code>char *</code>) to a wide-character string (<code>wchar_t *</code>).</p>
+  <p>This cast might yield strings that are not correctly terminated; including potential buffer overruns when using such strings with some dangerous APIs.</p>
+  <p>This version of the query is a subset of the GitHub query with ID <code>>cpp/incorrect-string-type-conversion</code> that limits the detection of <code>PUCHAR</code> casting to avoid certain commonly used patterns.</p>
+</overview>
+
+<recommendation>
+  <p>Do not explicitly cast byte strings to wide-character strings.</p>
+  <p>For string literals, prepend the literal string with the letter "L" to indicate that the string is a wide-character string (<code>wchar_t *</code>).</p>
+  <p>For converting a byte literal to a wide-character string literal, you would need to use the appropriate conversion function for the platform you are using. Please see the references section for options according to your platform.</p>
+</recommendation>
+
+<example>
+<p>In the following example, an byte string literal (<code>"a"</code>) is cast to a wide-character string.</p>
+<sample src="WcharCharConversion.cpp" />
+
+<p>To fix this issue, prepend the literal with the letter "L" (<code>L"a"</code>) to define it as a wide-character string.</p>
+</example>
+
+<references>
+  <li>
+    General resources:
+    <a href="https://en.cppreference.com/w/cpp/string/multibyte/mbstowcs">std::mbstowcs</a>
+  </li>
+  <li>
+    Microsoft specific resources:
+    <a href="https://docs.microsoft.com/en-us/windows/desktop/Intl/security-considerations--international-features">Security Considerations: International Features</a>
+  </li>
+</references>
+
+</qhelp>

--- a/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.ql
+++ b/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.ql
@@ -11,7 +11,8 @@
  * @precision high
  * @tags security
  *       external/cwe/cwe-704
- */
+ * @query-version 1.0
+*/
 
 import cpp
 

--- a/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.ql
+++ b/codeql/windows-drivers/queries/Security/CWE/CWE-704/WcharCharConversionLimited.ql
@@ -1,0 +1,32 @@
+/**
+ * @name Cast from char* to wchar_t* (ignore PUCHAR casts)
+ * @description Casting a byte string to a wide-character string is likely
+ *              to yield a string that is incorrectly terminated or aligned.
+ *              This can lead to undefined behavior, including buffer overruns.
+ *              This query is a specilized version of `cpp/incorrect-string-type-conversion` that ignores casting to `PUCHAR`
+ * @kind problem
+ * @id cpp/incorrect-string-type-conversion-isgnore-puchar-casts
+ * @problem.severity error
+ * @security-severity 8.8
+ * @precision high
+ * @tags security
+ *       external/cwe/cwe-704
+ */
+
+import cpp
+
+class WideCharPointerType extends PointerType {
+  WideCharPointerType() { this.getBaseType() instanceof WideCharType }
+}
+
+from Expr e1, Cast e2
+where
+  e2 = e1.getConversion() and
+  exists(WideCharPointerType w, CharPointerType c |
+    w = e2.getUnspecifiedType().(PointerType) and
+    c = e1.getUnspecifiedType().(PointerType) and
+    not c.getBaseType() instanceof UnsignedCharType // Eliminate False Postives caused by PUCHAR used as a generic byte stream
+  )
+select e1,
+  "Conversion from " + e1.getType().toString() + " to " + e2.getType().toString() +
+    ". Use of invalid string can lead to undefined behavior."

--- a/codeql/windows-drivers/queries/suites/windows_driver_mustfix.qls
+++ b/codeql/windows-drivers/queries/suites/windows_driver_mustfix.qls
@@ -11,9 +11,9 @@
       - Likely Bugs/Underspecified Functions/TooFewArguments.ql
       - Security/CWE/CWE-190/ComparisonWithWiderType.ql
       - Security/CWE/CWE-253/HResultBooleanConversion.ql
-      - Security/CWE/CWE-704/WcharCharConversion.ql
 - queries: .
   from: windows-drivers
 - include:
     query path: 
       - Windows/wdk/wdk-deprecated-api.ql
+      - Security/CWE/CWE-704/WcharCharConversionLimited.ql

--- a/codeql/windows-drivers/queries/suites/windows_driver_recommended.qls
+++ b/codeql/windows-drivers/queries/suites/windows_driver_recommended.qls
@@ -30,3 +30,4 @@
       - Likely Bugs/Memory Management/UseAfterFree/UseAfterFree.ql
       - Likely Bugs/UninitializedPtrField.ql
       - Security/Crytpography/HardcodedIVCNG.ql
+      - Security/CWE/CWE-704/WcharCharConversionLimited.ql


### PR DESCRIPTION
Since the original query is GitHub published, and the PUCHAR false positive pattern seems to be specific to driver writers, we are adding a new query to address the FPs, while keeping the original query under the `recommended` category.