### PR TITLE
Updates repo to use CodeQL v2.11.5

### DIFF
--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -1,5 +1,5 @@
 # Continuous integration action for the CodeQL components of this repo.
-# This downloads the CodeQL CLI and then builds all the queries in the "windows-drivers" folder.
+# This workflow downloads the CodeQL CLI and builds all the queries.
 
 name: Build Windows CodeQL queries
 
@@ -25,13 +25,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: .
-        submodules: recursive
     - name: Download CodeQL CLI
       uses: i3h/download-release-asset@v1.2.0
       with:
         owner: "github"
         repo: "codeql-cli-binaries"
-        tag: "v2.6.3"
+        tag: "v2.11.5"
         file: "codeql-win64.zip"
     - name: Unzip CodeQL CLI
       run: Expand-Archive -Path codeql-win64.zip -DestinationPath .\codeql-zip -Force
@@ -39,6 +38,12 @@ jobs:
       shell: cmd
       continue-on-error: true # Required because robocopy returns 1 on success
       run: robocopy /S /move .\codeql-zip\codeql .\codeql-cli\
+    
+    - name: Install CodeQL Packages
+      shell: cmd
+      continue-on-error: true
+      run: .\codeql-cli\codeql.cmd package install .\
+
     - name: Build must-fix driver suite
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only windows_driver_mustfix.qls

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -21,10 +21,12 @@ jobs:
     - name: Enable long git paths
       shell: cmd
       run: git config --global core.longpaths true
+    
     - name: Clone self (windows-driver-developer-supplemental-tools)
       uses: actions/checkout@v2
       with:
         path: .
+    
     - name: Download CodeQL CLI
       uses: i3h/download-release-asset@v1.2.0
       with:
@@ -32,8 +34,10 @@ jobs:
         repo: "codeql-cli-binaries"
         tag: "v2.11.5"
         file: "codeql-win64.zip"
+    
     - name: Unzip CodeQL CLI
       run: Expand-Archive -Path codeql-win64.zip -DestinationPath .\codeql-zip -Force
+    
     - name: Move CodeQL CLI folder to correct location
       shell: cmd
       continue-on-error: true # Required because robocopy returns 1 on success
@@ -42,17 +46,20 @@ jobs:
     - name: Install CodeQL Packages
       shell: cmd
       continue-on-error: true
-      run: .\codeql-cli\codeql.cmd package install .\
+      run: .\codeql-cli\codeql.cmd pack install .\windows-driver-developer-supplemental-tools\src
 
     - name: Build must-fix driver suite
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only windows_driver_mustfix.qls
+    
     - name: Build recommended driver suite
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only windows_driver_recommended.qls
+    
     - name: Build CA ported queries
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only ported_driver_ca_checks.qls
+    
     - name: Build all Windows queries
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only .\src

--- a/README.md
+++ b/README.md
@@ -2,33 +2,39 @@
 
 This repository contains open-source components for supplemental use in developing device drivers for Windows, as well as driver specific [CodeQL](https://codeql.github.com/) query suites used for the [Windows Hardware Compatibility Program](https://learn.microsoft.com/en-us/windows-hardware/design/compatibility/). The quickstart below will get you set up to build your database and analyze your driver using CodeQL. For the full documentation, troubleshooting, and more details about the Static Tools Logo test within the WHCP Program, please visit [CodeQL and the Static Tools Logo Test](https://docs.microsoft.com/windows-hardware/drivers/devtest/static-tools-and-codeql).
 
-### Windows Hardware Compatibility Program Release Version Matrix
+### For General Use
+
+| Branch to use            | CodeQL CLI version |
+|--------------------------|--------------------|
+| main                     | 2.11.5             |
+
+### For Windows Hardware Compatibility Program Use
+
 | Release                  | Branch to use | CodeQL CLI version |
 |--------------------------|---------------|--------------------|
 | Windows Server 2022      | WHCP_21H2     | 2.4.6              |
 | Windows 11               | WHCP_21H2     | 2.4.6              |
 | Windows 11, version 22H2 | WHCP_22H2     | 2.6.3              |
 
-For general use, use the `main` branch along with [version 2.6.3 of the CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.3).
+For general use, use the `main` branch along with [version 2.11.5 of the CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases/tag/v2.11.5).
 
 ## Quickstart
-**Note**: If you are certifying with the [**WHCP program**](https://learn.microsoft.com/en-us/windows-hardware/design/compatibility/), please refer to the above table to determine which branch and CodeQL CLI version to use, otherwise use `main` and [version 2.6.3 of the CodeQL CLI](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.3).
 
 1. Create a directory where you can place the CodeQL CLI and the queries you want to use:
     ```
     D:\> mkdir codeql-home
     ```
 
-1. Download the CodeQL CLI zip by selecting the asset associated with your OS and architecture (codeql-win64.zip, codeql-linux64.zip, etc.), then extract it to the directory you created.
+1. Download the CodeQL CLI zip by selecting the asset associated with your OS and architecture (codeql-win64.zip, codeql-linux64.zip, etc.), then extract it to the directory you created in the previous step.
 
     For the WHCP Program, use the CodeQL CLI version in accordance with the table above and Windows release you are certifying for: [version 2.4.6](https://github.com/github/codeql-cli-binaries/releases/tag/v2.4.6) or [version 2.6.3](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.3).
 
-    For general use with the `main` branch, use [CodeQL CLI version 2.6.3](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.3).
+    For general use with the `main` branch, use [CodeQL CLI version 2.11.5](https://github.com/github/codeql-cli-binaries/releases/tag/v2.11.5).
     
 
 1. Clone and install the Windows Driver Developer Supplemental Tools repository which contains the CodeQL queries specific for drivers:
     ```
-    D:\codeql-home\>git clone https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools.git --recursive -b <BRANCH>
+    D:\codeql-home\>git clone https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools.git
     ```
     Now you should have:
     ```
@@ -37,15 +43,20 @@ For general use, use the `main` branch along with [version 2.6.3 of the CodeQL C
             |--- Windows-Driver-Developer-Supplemental-Tools
     ```
 
-1. Verify everything is installed correctly by checking the version:
+1. Verify CodeQL is installed correctly by checking the version:
     ```
     D:\codeql-home\codeql>codeql --version
-        CodeQL command-line toolchain release 2.6.3.
-        Copyright (C) 2019-2021 GitHub, Inc.
-        Unpacked in: D:\codeql-home\codeql
-            Analysis results depend critically on separately distributed query and
-            extractor modules. To list modules that are visible to the toolchain,
-            use 'codeql resolve qlpacks' and 'codeql resolve languages'.
+    CodeQL command-line toolchain release 2.11.5.
+    Copyright (C) 2019-2022 GitHub, Inc.
+    Unpacked in: D:\codeql-home\codeql
+        Analysis results depend critically on separately distributed query and
+        extractor modules. To list modules that are visible to the toolchain,
+        use 'codeql resolve qlpacks' and 'codeql resolve languages'.
+    ```
+
+1. Install CodeQL Packages using `codeql pack install`
+    ```
+    D:\codeql-home\codeql>codeql pack install D:\codeql-home\Windows-Driver-Developer-Supplemental-Tools\src
     ```
 
 1. Build your CodeQL database:

--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -1,0 +1,2 @@
+provide:
+  - src/qlpack.yml

--- a/src/codeql-pack.lock.yml
+++ b/src/codeql-pack.lock.yml
@@ -1,0 +1,10 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.3.5
+  codeql/cpp-queries:
+    version: 0.2.0
+  codeql/suite-helpers:
+    version: 0.1.0
+compiled: false

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-name: windows-drivers
-version: 0.9.6
-libraryPathDependencies: 
-    - codeql/cpp-queries
-    - codeql/cpp-all
+name: microsoft/windows-drivers
+version: 0.1.0
 dependencies:
-    codeql/cpp-queries: "*"
+    codeql/cpp-queries: ^0.2.0
+    codeql/cpp-all: ^0.3.0
 suites: suites
 extractor: cpp
+licenses: MIT
+description: CodeQL queries designed for Windows device driver development.

--- a/src/suites/ported_driver_ca_checks.qls
+++ b/src/suites/ported_driver_ca_checks.qls
@@ -2,7 +2,7 @@
 
 - description: Ported CA checks
 - queries: .
-  from: windows-drivers
+  from: microsoft/windows-drivers
 - include:
     query path: 
       - drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.ql

--- a/src/suites/windows_driver_mustfix.qls
+++ b/src/suites/windows_driver_mustfix.qls
@@ -12,7 +12,7 @@
       - Security/CWE/CWE-190/ComparisonWithWiderType.ql
       - Security/CWE/CWE-253/HResultBooleanConversion.ql
 - queries: .
-  from: windows-drivers
+  from: microsoft/windows-drivers
 - include:
     query path: 
       - drivers/general/queries/WdkDeprecatedApis/wdk-deprecated-api.ql

--- a/src/suites/windows_driver_recommended.qls
+++ b/src/suites/windows_driver_recommended.qls
@@ -22,7 +22,7 @@
       - Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
       - Security/CWE/CWE-704/WcharCharConversion.ql
 - queries: .
-  from: windows-drivers
+  from: microsoft/windows-drivers
 - include:
     query path: 
       - microsoft/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosure.ql


### PR DESCRIPTION
Updates CodeQL version from 2.6.3. to 2.11.5
- Readme - adds in new procedure for users to run analysis & links to new CodeQL CLI version
- Removes codeql-queries submodule
- Package version *not* updated since there is no substantial change to it
- Unit Tests *not* run due to test process being in active development
- Commands `codeql database create` and `codeql database analyze` have completed successfully