### PR TITLE
Update CodeQL pack references to match CLI 2.11.5.

### DIFF
--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -45,7 +45,6 @@ jobs:
     
     - name: Install CodeQL Packages
       shell: cmd
-      continue-on-error: true
       run: .\codeql-cli\codeql.cmd pack install .\windows-driver-developer-supplemental-tools\src
 
     - name: Build must-fix driver suite

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -1,5 +1,5 @@
 # Continuous integration action for the CodeQL components of this repo.
-# This workflow downloads the CodeQL CLI and builds all the queries.
+# This downloads the CodeQL CLI and then builds all the queries in the "windows-drivers" folder.
 
 name: Build Windows CodeQL queries
 
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: .
+        submodules: recursive
     
     - name: Download CodeQL CLI
       uses: i3h/download-release-asset@v1.2.0
@@ -38,15 +39,18 @@ jobs:
     - name: Unzip CodeQL CLI
       run: Expand-Archive -Path codeql-win64.zip -DestinationPath .\codeql-zip -Force
     
-    - name: Move CodeQL CLI folder to correct location
+    - name: Move CodeQL CLI folder to main subdirectory
       shell: cmd
       continue-on-error: true # Required because robocopy returns 1 on success
       run: robocopy /S /move .\codeql-zip\codeql .\codeql-cli\
     
-    - name: Install CodeQL Packages
+    - name: Install CodeQL pack dependencies
       shell: cmd
-      run: .\codeql-cli\codeql.cmd pack install .\windows-driver-developer-supplemental-tools\src
-
+      run: |
+        pushd .\src 
+        ..\codeql-cli\codeql.cmd pack install 
+        popd
+    
     - name: Build must-fix driver suite
       shell: cmd
       run: .\codeql-cli\codeql.cmd query compile --check-only windows_driver_mustfix.qls

--- a/.github/workflows/build-codeql.yaml
+++ b/.github/workflows/build-codeql.yaml
@@ -26,7 +26,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: .
-        submodules: recursive
     
     - name: Download CodeQL CLI
       uses: i3h/download-release-asset@v1.2.0

--- a/src/codeql-pack.lock.yml
+++ b/src/codeql-pack.lock.yml
@@ -2,9 +2,11 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/cpp-all:
-    version: 0.3.5
+    version: 0.4.6
+  codeql/ssa:
+    version: 0.0.7
   codeql/cpp-queries:
-    version: 0.2.0
+    version: 0.4.6
   codeql/suite-helpers:
-    version: 0.1.0
+    version: 0.3.6
 compiled: false

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -4,8 +4,8 @@
 name: microsoft/windows-drivers
 version: 0.1.0
 dependencies:
-    codeql/cpp-queries: ^0.4.0
-    codeql/cpp-all: ^0.4.0
+    codeql/cpp-queries: ^0.4.5
+    codeql/cpp-all: ^0.4.5
 suites: suites
 extractor: cpp
 licenses: MIT

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -4,8 +4,8 @@
 name: microsoft/windows-drivers
 version: 0.1.0
 dependencies:
-    codeql/cpp-queries: ^0.2.0
-    codeql/cpp-all: ^0.3.0
+    codeql/cpp-queries: ^0.4.0
+    codeql/cpp-all: ^0.4.0
 suites: suites
 extractor: cpp
 licenses: MIT


### PR DESCRIPTION
The recent update to CLI version 2.11.5 did not update the associated CodeQL core library/query packs.  To ensure we have good alignment between the CLI and the libraries, this change updates our pack dependencies.  Users should re-run "codeql pack install" from the src directory after this change.

The dependency version was taken from these files: 
https://github.com/github/codeql/blob/codeql-cli/v2.11.5/cpp/ql/src/qlpack.yml
https://github.com/github/codeql/blob/codeql-cli/v2.11.5/cpp/ql/lib/qlpack.yml

## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [X] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.