### PR TITLE
Fix typo in WcharCharConversionLimited.ql

### DIFF
--- a/src/microsoft/Security/CWE/CWE-704/WcharCharConversionLimited.ql
+++ b/src/microsoft/Security/CWE/CWE-704/WcharCharConversionLimited.ql
@@ -5,7 +5,7 @@
  *              This can lead to undefined behavior, including buffer overruns.
  *              This query is a specilized version of `cpp/incorrect-string-type-conversion` that ignores casting to `PUCHAR`
  * @kind problem
- * @id cpp/incorrect-string-type-conversion-isgnore-puchar-casts
+ * @id cpp/incorrect-string-type-conversion-ignore-puchar-casts
  * @problem.severity error
  * @security-severity 8.8
  * @precision high


### PR DESCRIPTION
Quick fix to a typo in WcharCharConversionLimited.ql.

Fixes #46.

## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [X] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.