### PR TITLE
Fix two benign test issues that were causing noise.

### DIFF
--- a/src/drivers/test/build_create_analyze_test.cmd
+++ b/src/drivers/test/build_create_analyze_test.cmd
@@ -16,7 +16,7 @@ call :test IllegalFieldAccess WDMTestTemplate wdm queries
 call :test PoolTagIntegral WDMTestTemplate general queries
 call :test ObReferenceMode WDMTestTemplate wdm queries
 call :test DeviceInitApi KMDFTestTemplate kmdf queries\experimental
-call :test DefaultPoolTag WDMTestingTemplate general queries
+call :test DefaultPoolTag WDMTestTemplate general queries
 call :test DefaultPoolTagExtended WDMTestTemplate general queries\experimental
 call :test InitNotCleared WDMTestTemplate wdm queries
 call :test IrqlNotUsed WDMTestTemplate general queries

--- a/src/drivers/wdm/queries/KeWaitLocal/KeWaitLocal.sarif
+++ b/src/drivers/wdm/queries/KeWaitLocal/KeWaitLocal.sarif
@@ -1,370 +1,52 @@
 {
-  "$schema" : "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "version" : "2.1.0",
   "runs" : [ {
     "tool" : {
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.6.3",
+        "semanticVersion" : "2.11.5",
         "rules" : [ {
-          "id" : "cpp/portedqueries/ke-wait-local",
-          "name" : "cpp/portedqueries/ke-wait-local",
+          "id" : "cpp/drivers/kewaitlocal-requires-kernel-mode",
+          "name" : "cpp/drivers/kewaitlocal-requires-kernel-mode",
           "shortDescription" : {
             "text" : "KeWaitLocal"
           },
           "fullDescription" : {
-            "text" : "If the first argument to KeWaitForSingleObject is a local variable, the Mode parameter must be KernelMode"
+            "text" : "When the first argument to KeWaitForSingleObject is a local variable, the Mode parameter must be KernelMode."
           },
           "defaultConfiguration" : {
             "enabled" : true,
             "level" : "error"
           },
           "properties" : {
-            "description" : "If the first argument to KeWaitForSingleObject is a local variable, the Mode parameter must be KernelMode",
+            "description" : "When the first argument to KeWaitForSingleObject is a local variable, the Mode parameter must be KernelMode.",
             "feature.area" : "Multiple",
-            "id" : "cpp/portedqueries/ke-wait-local",
+            "id" : "cpp/drivers/kewaitlocal-requires-kernel-mode",
+            "impact:" : "Exploitable Design",
             "kind" : "problem",
             "name" : "KeWaitLocal",
+            "owner.email:" : "sdat@microsoft.com",
             "platform" : "Desktop",
+            "precision" : "high",
             "problem.severity" : "error",
-            "repro.text" : "The following code locations potentially contain KeWaitForSingleObject where the Mode parameter is not KernelMode",
-            "version" : "1.0"
+            "query-version" : "1.0",
+            "repro.text" : "The following code locations contain a call to KeWaitForSingleObject while waiting for a local kernel-mode object, but the Mode parameter has not been set to KernelMode.",
+            "security.severity:" : "Low"
           }
         } ]
       },
       "extensions" : [ {
-        "name" : "codeql/java-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
+        "name" : "microsoft/windows-drivers",
+        "semanticVersion" : "0.1.0+49dac27a0f5a5406cdaad6c6b32b20e47aef0459",
         "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/upgrades/",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
             "text" : "The QL pack root directory."
           }
         }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-queries",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-javascript-examples",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/suite-helpers",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/suite-helpers/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/suite-helpers/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-javascript",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/javascript/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/javascript/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-java-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-upgrades",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests-cwe-190-tainted",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-python",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/python/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/python/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-java",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/java/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/java/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-cpp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/cpp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/cpp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/cpp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/lib/qlpack.yml",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -373,222 +55,12 @@
         "name" : "legacy-upgrades",
         "semanticVersion" : "0.0.0",
         "locations" : [ {
-          "uri" : "file:///D:/codeql/legacy-upgrades/",
+          "uri" : "file:///C:/codeql-home/codeql/legacy-upgrades/",
           "description" : {
             "text" : "The QL pack root directory."
           }
         }, {
-          "uri" : "file:///D:/codeql/legacy-upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-tests",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/python/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-all",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/javascript/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-consistency-queries",
-        "semanticVersion" : "0.0.1+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/consistency-queries/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/consistency-queries/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-csharp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/csharp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/misc/legacy-support/csharp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/ruby/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "windows-drivers",
-        "semanticVersion" : "0.9.6+aceeb5151763251a996beb00221687110f073552",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/windows-drivers/queries/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/windows-drivers/queries/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/java/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///D:/Windows-Driver-Developer-Supplemental-Tools/codeql/codeql-queries/csharp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "windows-drivers",
-        "semanticVersion" : "0.9.6+c3543727d60567da20110852e5d0cee046efc4f0",
-        "locations" : [ {
-          "uri" : "file:///E:/Windows-Driver-Developer-Supplemental-Tools/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///E:/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
+          "uri" : "file:///C:/codeql-home/codeql/legacy-upgrades/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -603,10 +75,10 @@
       }
     } ],
     "results" : [ {
-      "ruleId" : "cpp/portedqueries/ke-wait-local",
+      "ruleId" : "cpp/drivers/kewaitlocal-requires-kernel-mode",
       "ruleIndex" : 0,
       "rule" : {
-        "id" : "cpp/portedqueries/ke-wait-local",
+        "id" : "cpp/drivers/kewaitlocal-requires-kernel-mode",
         "index" : 0
       },
       "message" : {
@@ -621,14 +93,14 @@
           },
           "region" : {
             "startLine" : 10,
-            "startColumn" : 28,
-            "endColumn" : 35
+            "startColumn" : 5,
+            "endColumn" : 26
           }
         }
       } ],
       "partialFingerprints" : {
         "primaryLocationLineHash" : "61bc3c7079348327:1",
-        "primaryLocationStartColumnFingerprint" : "23"
+        "primaryLocationStartColumnFingerprint" : "0"
       }
     } ],
     "columnKind" : "utf16CodeUnits",


### PR DESCRIPTION
KeWaitLocal had an outdated test baseline (due to changes in its metadata, but no changes to the query itself) and DefaultPoolTag had a typo in the test script that resulted in its test failing to run.  This change fixes both those issues and returns the test baseline to a clean state.

## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [X] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.