### PR TITLE
Improve messaging for WdkDeprecatedApis check.

### DIFF
--- a/src/drivers/general/queries/WdkDeprecatedApis/WdkDeprecatedApis.sarif
+++ b/src/drivers/general/queries/WdkDeprecatedApis/WdkDeprecatedApis.sarif
@@ -1,12 +1,12 @@
 {
-  "$schema" : "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "version" : "2.1.0",
   "runs" : [ {
     "tool" : {
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.6.3",
+        "semanticVersion" : "2.11.6",
         "rules" : [ {
           "id" : "cpp/windows/wdk/deprecated-api",
           "name" : "cpp/windows/wdk/deprecated-api",
@@ -29,57 +29,15 @@
             "name" : "Use of deprecated WDK API",
             "platform" : "Desktop",
             "problem.severity" : "warning",
-            "query-version" : "1.2",
+            "query-version" : "1.3",
             "repro.text" : "The following code locations contain calls to a deprecated WDK API",
             "security.severity" : "Low"
           }
         } ]
       },
       "extensions" : [ {
-        "name" : "codeql/csharp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "windows-drivers",
-        "semanticVersion" : "0.9.6+67df68853938aee1d7921882dd2d71cfcca854e9",
+        "name" : "microsoft/windows-drivers",
+        "semanticVersion" : "0.1.0+60d1aca7624cfa2ad3b9c3a3e79096f21d59d977",
         "locations" : [ {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
@@ -87,146 +45,6 @@
           }
         }, {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-java-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-csharp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/csharp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/csharp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-upgrades",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-queries",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/upgrades/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -245,342 +63,6 @@
             "text" : "The QL pack definition file."
           }
         } ]
-      }, {
-        "name" : "codeql/suite-helpers",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/suite-helpers/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/suite-helpers/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-all",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-cpp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/cpp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/cpp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-javascript-examples",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-javascript",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/javascript/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/javascript/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-java",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/java/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/java/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests-cwe-190-tainted",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-python",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/python/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/python/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-tests",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-consistency-queries",
-        "semanticVersion" : "0.0.1+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/consistency-queries/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/consistency-queries/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
       } ]
     },
     "artifacts" : [ {
@@ -591,6 +73,34 @@
       }
     } ],
     "results" : [ {
+      "ruleId" : "cpp/windows/wdk/deprecated-api",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/wdk/deprecated-api",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "Using deprecated API 'ExAllocatePoolWithTag'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2\nUsing deprecated API 'ExAllocatePool'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 30,
+            "startColumn" : 5,
+            "endColumn" : 68
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "7fe183293afd1fdc:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
       "ruleId" : "cpp/windows/wdk/deprecated-api",
       "ruleIndex" : 0,
       "rule" : {
@@ -615,7 +125,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "41447b0814eeecd3:1",
+        "primaryLocationLineHash" : "550333300fe9fc29:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     } ],

--- a/src/drivers/general/queries/WdkDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/WdkDeprecatedApis/driver_snippet.c
@@ -20,3 +20,12 @@ VOID WdkDeprecatedApi_Fail()
 {
     ExAllocatePool(POOL_FLAG_NON_PAGED, sizeof(int));
 }
+
+// Failing case: call a macro invocation of an obsolete API
+VOID WdkDeprecatedApi_Fail2()
+{
+#ifndef ExAllocatePoolWithTag(a, b, c)
+#define ExAllocatePoolWithTag(a, b, c) ExAllocatePool(a, b)
+#endif
+    ExAllocatePoolWithTag(POOL_FLAG_NON_PAGED, sizeof(int), '_gaT');
+}

--- a/src/drivers/general/queries/WdkDeprecatedApis/wdk-deprecated-api.ql
+++ b/src/drivers/general/queries/WdkDeprecatedApis/wdk-deprecated-api.ql
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 /**
  * @name Use of deprecated WDK API
- * @description Use of deprecated WDK API detected. 
+ * @description Use of deprecated WDK API detected.
  * @platform Desktop
  * @security.severity Low
  * @impact Attack Surface Reduction
@@ -12,30 +11,120 @@
  * @kind problem
  * @id cpp/windows/wdk/deprecated-api
  * @problem.severity warning
- * @query-version 1.2
+ * @query-version 1.3
  */
 
 import cpp
 
-class WdkDeprecatedApiFunctionCall extends FunctionCall {
-    WdkDeprecatedApiFunctionCall() {
-          getTarget().hasGlobalName("ExAllocatePoolWithTag")
-       or getTarget().hasGlobalName("ExAllocatePool")
-       or getTarget().hasGlobalName("ExAllocatePoolWithQuota")
-       or getTarget().hasGlobalName("ExAllocatePoolWithQuotaTag")
-       or getTarget().hasGlobalName("ExAllocatePoolWithTagPriority")
-    }
-
-    string message() {
-       if (getTarget().hasGlobalName("ExAllocatePoolWithTag")) then(result = "Using deprecated API '" + getTarget().getQualifiedName() + "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2")
-       else if (getTarget().hasGlobalName("ExAllocatePool")) then(result = "Using deprecated API '" + getTarget().getQualifiedName() + "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2")
-       else if (getTarget().hasGlobalName("ExAllocatePoolWithQuota")) then(result = "Using deprecated API '" + getTarget().getQualifiedName() + "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2")
-       else if (getTarget().hasGlobalName("ExAllocatePoolWithQuotaTag")) then(result = "Using deprecated API '" + getTarget().getQualifiedName() + "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2")
-       else if (getTarget().hasGlobalName("ExAllocatePoolWithTagPriority")) then(result = "Using deprecated API '" + getTarget().getQualifiedName() + "'. Replacement function: ExAllocatePool3. For downlevel code, use ExAllocatePoolPriorityZero or ExAllocatePoolPriorityUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool3")
-       else (result = "Using deprecated API '" + getTarget().getQualifiedName() + "'.")
-    }
+/** Represents either a macro invocation of a deprecated allocation API, or a direct function call to a deprecated allocation API. */
+abstract class WdkDeprecatedApiCall extends Element {
+  /** Returns a message suggesting replacement APIs when calling a deprecated API. */
+  abstract string getMessage();
 }
 
-from WdkDeprecatedApiFunctionCall deprecatedCall
-where not deprecatedCall.getLocation().getFile().toString().matches("%Windows Kits%Include%.h")
-select deprecatedCall, deprecatedCall.message()
+/** Represents a function call to a now-deprecated memory allocation API. */
+class WdkDeprecatedApiFunctionCall extends FunctionCall, WdkDeprecatedApiCall {
+  WdkDeprecatedApiFunctionCall() {
+    getTarget().hasGlobalName("ExAllocatePoolWithTag") or
+    getTarget().hasGlobalName("ExAllocatePool") or
+    getTarget().hasGlobalName("ExAllocatePoolWithQuota") or
+    getTarget().hasGlobalName("ExAllocatePoolWithQuotaTag") or
+    getTarget().hasGlobalName("ExAllocatePoolWithTagPriority")
+  }
+
+  override string getMessage() {
+    if getTarget().hasGlobalName("ExAllocatePoolWithTag")
+    then
+      result =
+        "Using deprecated API '" + getTarget().getQualifiedName() +
+          "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+    else
+      if getTarget().hasGlobalName("ExAllocatePool")
+      then
+        result =
+          "Using deprecated API '" + getTarget().getQualifiedName() +
+            "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+      else
+        if getTarget().hasGlobalName("ExAllocatePoolWithQuota")
+        then
+          result =
+            "Using deprecated API '" + getTarget().getQualifiedName() +
+              "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+        else
+          if getTarget().hasGlobalName("ExAllocatePoolWithQuotaTag")
+          then
+            result =
+              "Using deprecated API '" + getTarget().getQualifiedName() +
+                "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+          else
+            if getTarget().hasGlobalName("ExAllocatePoolWithTagPriority")
+            then
+              result =
+                "Using deprecated API '" + getTarget().getQualifiedName() +
+                  "'. Replacement function: ExAllocatePool3. For downlevel code, use ExAllocatePoolPriorityZero or ExAllocatePoolPriorityUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool3"
+            else result = "Using deprecated API '" + getTarget().getQualifiedName() + "'."
+  }
+}
+
+/** Represents a macro version of the deprecated allocation APIs. */
+class WdkDeprecatedMacro extends Macro {
+  WdkDeprecatedMacro() {
+    this.getName()
+        .matches([
+            "ExAllocatePoolWithTag", "ExAllocatePool", "ExAllocatePoolWithQuota",
+            "ExAllocatePoolWithQuotaTag", "ExAllocatePoolWithTagPriority"
+          ])
+  }
+
+  /** Returns a message suggesting replacement APIs when calling a deprecated API. */
+  string message() {
+    if this.getName().matches("ExAllocatePoolWithTag")
+    then
+      result =
+        "Using deprecated API '" + this.getName() +
+          "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+    else
+      if this.getName().matches("ExAllocatePool")
+      then
+        result =
+          "Using deprecated API '" + this.getName() +
+            "'. Replacement function: ExAllocatePool2. For downlevel code, use ExAllocatePoolZero or ExAllocatePoolUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+      else
+        if this.getName().matches("ExAllocatePoolWithQuota")
+        then
+          result =
+            "Using deprecated API '" + this.getName() +
+              "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+        else
+          if this.getName().matches("ExAllocatePoolWithQuotaTag")
+          then
+            result =
+              "Using deprecated API '" + this.getName() +
+                "'. Replacement function: ExAllocatePool2 with POOL_FLAG_USE_QUOTA flag. For downlevel code, use ExAllocatePoolWithQuotaZero or ExAllocatePoolWithQuotaUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2"
+          else
+            if this.getName().matches("ExAllocatePoolWithTagPriority")
+            then
+              result =
+                "Using deprecated API '" + this.getName() +
+                  "'. Replacement function: ExAllocatePool3. For downlevel code, use ExAllocatePoolPriorityZero or ExAllocatePoolPriorityUninitialized. Do not use `POOL_FLAG_UNINITIALIZED` flag when fixing. For details, please visit https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool3"
+            else result = "Using deprecated API '" + this.getName() + "'."
+  }
+}
+
+/** Represents a macro invocation of a deprecated allocation API. */
+class WdkDeprecatedApiMacroInvocation extends MacroInvocation, WdkDeprecatedApiCall {
+  WdkDeprecatedApiMacroInvocation() { this.getMacro() instanceof WdkDeprecatedMacro }
+
+  override string getMessage() { result = this.getMacro().(WdkDeprecatedMacro).message() }
+}
+
+from WdkDeprecatedApiCall call
+where
+  // To avoid result duplication, exclude calls that are the result of expanding a deprecated macro
+  not (
+    call instanceof WdkDeprecatedApiFunctionCall and
+    exists(WdkDeprecatedApiMacroInvocation containingMi |
+      containingMi.getAnExpandedElement() = call
+    )
+  )
+select call, call.getMessage()


### PR DESCRIPTION
This change updates the WdkDeprecatedApis query to correctly report usages of deprecated APIs when they are in macro form.  Depending on the compilation environment, Windows may redefine i.e. ExAllocatePoolTag to ExAllocatePool.  Previously, this query would then report a call to ExAllocatePool, which, while technically correct, was confusing to the end user.  The error message will now report the macro call actually present in the code.

## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [X] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.