### PR TITLE
Create a library and query for converting Code Analysis-style suppressions to CodeQL suppressions.

### DIFF
--- a/src/drivers/general/DriverAlertSuppression.ql
+++ b/src/drivers/general/DriverAlertSuppression.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Driver alert suppression
+ * @description Suppresses alerts in Windows Drivers based on Code Analysis syntax.
+ * @kind alert-suppression
+ * @id cpp/windows/drivers/driver-alert-suppression
+ */
+
+private import drivers.libraries.Suppression
+
+from CASuppression cas, string text, string annotation, CASuppressionScope scope
+where
+  text = cas.toString() and // text of suppression comment (excluding delimiters)
+  annotation = cas.makeLgtmName() // text of suppression annotation
+  and cas.getScope() = scope // scope of suppression
+select cas, text, annotation, scope

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
@@ -1,20 +1,20 @@
 {
-  "$schema" : "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
   "version" : "2.1.0",
   "runs" : [ {
     "tool" : {
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.6.3",
+        "semanticVersion" : "2.11.5",
         "rules" : [ {
           "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
           "name" : "cpp/windows/drivers/queries/extended-deprecated-apis",
           "shortDescription" : {
-            "text" : "Use of deprecated function or macro (C28719, C28726, C28750)"
+            "text" : "Use of deprecated function or macro (C28719, C28726, C28735, C28750)"
           },
           "fullDescription" : {
-            "text" : "Unsafe, deprectated APIs should not be used. This is a port of Code Analysis checks C28719, C28726, and C28750."
+            "text" : "Unsafe, deprecated APIs should not be used. This is a port of Code Analysis checks C28719, C28726, and C28750."
           },
           "defaultConfiguration" : {
             "enabled" : true,
@@ -22,12 +22,12 @@
           },
           "properties" : {
             "tags" : [ "correctness" ],
-            "description" : "Unsafe, deprectated APIs should not be used.  This is a port of Code Analysis checks C28719, C28726, and C28750.",
+            "description" : "Unsafe, deprecated APIs should not be used.  This is a port of Code Analysis checks C28719, C28726, and C28750.",
             "feature.area" : "Multiple",
             "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
             "impact" : "Attack Surface Reduction",
             "kind" : "problem",
-            "name" : "Use of deprecated function or macro (C28719, C28726, C28750)",
+            "name" : "Use of deprecated function or macro (C28719, C28726, C28735, C28750)",
             "platform" : "Desktop",
             "precision" : "high",
             "problem.severity" : "warning",
@@ -38,71 +38,15 @@
         } ]
       },
       "extensions" : [ {
-        "name" : "codeql-java-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
+        "name" : "microsoft/windows-drivers",
+        "semanticVersion" : "0.1.0+10ae08b29e203859dc319a0a1eee2d7d87cd3f88",
         "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/examples/",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
             "text" : "The QL pack root directory."
           }
         }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/suite-helpers",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/suite-helpers/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/suite-helpers/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-tests",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/test/qlpack.yml",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -117,468 +61,6 @@
           }
         }, {
           "uri" : "file:///C:/codeql-home/codeql/legacy-upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-cpp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/cpp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/cpp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-python",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/python/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/python/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-javascript-examples",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-javascript",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/javascript/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/javascript/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-consistency-queries",
-        "semanticVersion" : "0.0.1+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/consistency-queries/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/consistency-queries/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-csharp",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/csharp/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/csharp/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-tests-cwe-190-tainted",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "windows-drivers",
-        "semanticVersion" : "0.9.6+7a14d654ca62830151bb67116f8fcbfc81c683fe",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/java-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/java/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/python-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/python/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/csharp-all",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-all",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/lib/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/lib/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/examples/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-queries",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-queries",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/ruby-tests",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/test/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/ruby/ql/test/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "legacy-libraries-java",
-        "semanticVersion" : "0.0.0+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/java/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/misc/legacy-support/java/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/cpp-upgrades",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/cpp/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql/javascript-upgrades",
-        "semanticVersion" : "0.0.3+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/upgrades/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/javascript/upgrades/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      }, {
-        "name" : "codeql-csharp-examples",
-        "semanticVersion" : "0.0.2+e1786262261474ddd372ad6eb02078d178f3f8e1",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/examples/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/codeql-queries/csharp/ql/examples/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -610,6 +92,314 @@
             "index" : 0
           },
           "region" : {
+            "startLine" : 37,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "2ebae78f14622650:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 40,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "e3b86354faff5cc5:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 42,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "ef6512d2da0af59c:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 44,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "edb7b00d5c78b908:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 46,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "9df002ac3942a1c8:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 49,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "3c680a64917ef518:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 51,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "9a9b276cd87e28c6:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 53,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "bbc0c7cbc3a8c61b:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 55,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "5774da00ce2ad9ba:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 58,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "5cf377904556a621:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 60,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "bb482f4293b46bf5:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
             "startLine" : 25,
             "startColumn" : 5,
             "endColumn" : 11
@@ -617,7 +407,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "af4c1b7ec005cdbe:1",
+        "primaryLocationLineHash" : "7b4677b91dfe9311:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     } ],

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -13,14 +13,49 @@ void top_level_call() {}
 VOID ExtendedDeprecatedApis_Pass()
 {
     PSTR src = "Passing case!";
-    char dst[100]; 
-    strcpy_s(dst, sizeof(dst), src); 
+    char dst[100];
+    strcpy_s(dst, sizeof(dst), src);
 }
 
 // Failing case: includes calls to deprecated APIs
 VOID ExtendedDeprecatedApis_Fail()
 {
     PSTR src = "Failing case, even though we have enough space!";
-    char dst[100]; 
-    strcpy(dst, src); 
+    char dst[100];
+    strcpy(dst, src);
+}
+
+/*  Test code for AlertSuppression.ql.
+    Because alert suppression queries don't directly output to SARIF,
+    this code should be built as a database and then have both ExtendedDeprecatedApis and
+    DriverAlertSuppression.ql run to test suppression. */
+VOID AlertSuppressionTesting()
+{
+    PSTR src = "Testing suppression";
+    char dst[100];
+
+    strcpy(dst, src); // Unsuppressed
+
+#pragma prefast(suppress : 28719)
+    strcpy(dst, src);
+#pragma prefast(suppress : 28719, "Suppression with comment")
+    strcpy(dst, src);
+#pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment")
+    strcpy(dst, src);
+#pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis)
+    strcpy(dst, src);
+#pragma prefast(suppress : 28719)
+#pragma prefast(suppress : 28720)
+    strcpy(dst, src); // BUG: Should be suppressed, isn't
+#pragma prefast(suppress : 28720 28719)
+    strcpy(dst, src); // BUG: Should be suppressed, isn't
+#pragma prefast(disable : 28719)
+    strcpy(dst, src); // BUG: Should be suppressed, isn't
+#pragma prefast(push)
+    strcpy(dst, src); // Unsuppressed
+
+#pragma prefast(disable : 28719)
+    strcpy(dst, src);
+#pragma prefast(pop)
+    strcpy(dst, src); // BUG: Should be suppressed, isn't
 }

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -1,0 +1,248 @@
+import cpp
+
+// Reference: https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170
+//TODO: Support pragmas that combine disable, suppress, etc. in a single line
+//TODO: Support LGTM-style comment suppression?
+/** Represents a Code Analysis-style suppression using #pragma commands. */
+abstract class CASuppression extends PreprocessorPragma {
+  abstract predicate matchesRuleName(string name);
+
+  /** Returns the rule name that was provided in the suppression. */
+  abstract string getRuleName();
+
+  /** Evaluates if the given location is suppressed by this suppression. */
+  abstract predicate appliesToLocation(Location l);
+
+  /** Returns the scope covered by this suppression. */
+  CASuppressionScope getScope() { result = this }
+
+  /** Given the CA rule ID or warning from a suppression or disable pragma, creates an LGTM-style suppression. */
+  string makeLgtmName() {
+    this.getRuleName() =
+      any([
+            "__WARNING_BANNED_API_USAGE", "28719",
+            "__WARNING_BANNED_LEGACY_INSTRUMENTATION_API_USAGE",
+            "__WARNING_BANNED_CRIMSON_API_USAGE", "28735", "__WARNING_BANNED_API_USAGEL2", "28726",
+            "__WARNING_BANNED_API_USAGE_LSTRLEN", "28750"
+          ]
+      ) and
+    result = "lgtm[cpp/windows/drivers/queries/extended-deprecated-apis]"
+    or
+    this.getRuleName() = any(["__WARNING_UNHELPFUL_TAG", "28147"]) and
+    result =
+      any([
+            "lgtm[cpp/windows/drivers/queries/default-pool-tag]",
+            "lgtm[cpp/windows/drivers/queries/default-pool-tag-extended]"
+          ]
+      )
+    or
+    this.getRuleName() = any(["__WARNING_IRQL_NOT_SET", "28158"]) and
+    result = "lgtm[cpp/drivers/irql-not-saved]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQL_NOT_USED", "28157"]) and
+    result = "lgtm[cpp/drivers/irql-not-used]"
+    or
+    this.getRuleName() = any(["__WARNING_POOL_TAG", "28134"]) and
+    result = "lgtm[cpp/windows/drivers/queries/pool-tag-integral]"
+    or
+    this.getRuleName() = any(["__WARNING_STRSAFE_H", "28146"]) and
+    result = "lgtm[cpp/portedqueries/str-safe]"
+    or
+    this.getRuleName() = any(["__WARNING_MUST_USE", "28193"]) and
+    result = "lgtm[cpp/portedqueries/examined-value]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
+    result = "lgtm[cpp/portedqueries/irq-too-low]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_TOO_HIGH", "28121"]) and
+    result = "lgtm[cpp/portedqueries/irq-too-high]"
+    or
+    this.getRuleName() = any(["__WARNING_FUNCTION_ASSIGNMENT", "28128"]) and
+    result = "lgtm[cpp/windows/drivers/queries/illegal-field-access]"
+    or
+    this.getRuleName() = any(["__WARNING_INACCESSIBLE_MEMBER", "28175"]) and
+    result = "lgtm[cpp/windows/drivers/queries/illegal-field-access-2]"
+    or
+    this.getRuleName() = any(["__WARNING_READ_ONLY_MEMBER", "28176"]) and
+    result = "lgtm[cpp/windows/drivers/queries/illegal-field-write]"
+    or
+    this.getRuleName() = any(["__WARNING_INIT_NOT_CLEARED", "28152"]) and
+    result = "lgtm[cpp/windows/drivers/queries/init-not-cleared]"
+    or
+    this.getRuleName() = any(["__WARNING_KE_WAIT_LOCAL", "28135"]) and
+    result = "lgtm[cpp/drivers/kewaitlocal-requires-kernel-mode]"
+    or
+    this.getRuleName() = any(["__WARNING_MULTIPLE_PAGED_CODE", "28171"]) and
+    result = "lgtm[cpp/portedqueries/multiple-paged-code]"
+    or
+    this.getRuleName() = any(["__WARNING_NO_PAGED_CODE", "28170"]) and
+    result = "lgtm[cpp/portedqueries/no-paged-code]"
+    or
+    this.getRuleName() = any(["__WARNING_NO_PAGING_SEGMENT", "28172"]) and
+    result = "lgtm[cpp/portedqueries/no-paging-segment]"
+    or
+    this.getRuleName() = any(["__WARNING_OBJ_REFERENCE_MODE", "28126"]) and
+    result = "lgtm[cpp/windows/drivers/queries/ob-reference-mode]"
+    or
+    this.getRuleName() = any(["__WARNING_MODIFYING_MDL", "28145"]) and
+    result = "lgtm[cpp/windows/drivers/queries/opaquemdlwrite]"
+    or
+    this.getRuleName() = any(["__WARNING_PENDING_STATUS_ERROR", "28143"]) and
+    result = "lgtm[cpp/portedqueries/pending-status-error]"
+    or
+    this.getRuleName() =
+      any(["__WARNING_DISPATCH_MISMATCH", "28168", "__WARNING_DISPATCH_MISSING", "28169"]) and
+    result = "lgtm[cpp/portedqueries/wrong-dispatch-table-assignment]"
+    or
+    result = "lgtm[" + this.getRuleName() + "]"
+  }
+}
+
+/** Represents the scope covered by a given CA supression. */
+class CASuppressionScope extends ElementBase instanceof CASuppression {
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    exists(Location l |
+      l.getFile().getAbsolutePath() = filepath and
+      l.getStartLine() = startline and
+      l.getStartColumn() = startcolumn and
+      l.getEndLine() = endline and
+      l.getEndColumn() = endcolumn and
+      super.appliesToLocation(l)
+    )
+  }
+}
+
+/**
+ * Represents a #pragma warning(suppress:) statement, which suppresses a given warning on the following
+ * line of actual code.
+ */
+class SuppressPragma extends CASuppression {
+  string suppressedRule;
+
+  // TODO: Support #pragma warning(suppress:28104 28161 6001 6101) - i.e. multiple suppresses in one line
+  SuppressPragma() {
+    suppressedRule =
+      any(string s |
+        exists(int n |
+          s =
+            this.getHead()
+                .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w]+)[\\s\\d\\w\\W]*\\)", n)
+          or
+          suppressedRule =
+            this.getHead()
+                .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w]+)[\\s\\d\\w\\W]*\\)", n)
+        )
+      )
+  }
+
+  pragma[inline]
+  override predicate matchesRuleName(string name) { name = suppressedRule }
+
+  pragma[inline]
+  override string getRuleName() { result = suppressedRule }
+
+  override predicate appliesToLocation(Location l) {
+    this.getFile() = l.getFile() and
+    this.getLocation().getEndLine() + 1 = l.getStartLine()
+    // TODO: Support case where multiple suppressions are stacked on consecutive lines
+  }
+}
+
+/**
+ * Represents a #pragma warning(disable:) statement, which suppresses the given warning indefinitely
+ * until the pragma state is pushed or popped, or until an enable statement is used (enable not yet implemented).
+ */
+class DisablePragma extends CASuppression {
+  string disabledRule;
+
+  // TODO: Support #pragma warning(disable:28104 28161 6001 6101) - i.e. multiple rules disabled in one line
+  DisablePragma() {
+    disabledRule =
+      this.getHead().regexpCapture("warning\\s*\\(\\s*disable\\s*:\\s*([\\d\\w]+)\\s*\\)", 1) or
+    disabledRule =
+      this.getHead().regexpCapture("prefast\\s*\\(\\s*disable\\s*:\\s*([\\d\\w]+)\\s*\\)", 1)
+  }
+
+  pragma[inline]
+  override predicate matchesRuleName(string name) { name = disabledRule }
+
+  pragma[inline]
+  override string getRuleName() { result = disabledRule }
+
+  pragma[inline]
+  override predicate appliesToLocation(Location l) {
+    this.getFile() = l.getFile() and
+    this.getLocation().getEndLine() <= l.getStartLine() and
+    // If we're in a pragma push/pop, ensure the disable is too
+    exists(SuppressionPushPopSegment spps |
+      spps.getADisablePragma() = this and
+      spps.isInPushPopSegment(l)
+    )
+    // TODO: Handle case where the disable is outside push/pop
+  }
+}
+
+/** Represents a pragma push statement. */
+class SuppressionPushPragma extends PreprocessorPragma {
+  boolean isWarning;
+
+  SuppressionPushPragma() {
+    this.getHead().regexpMatch("warning\\s*\\(\\s*push\\s*\\)") and isWarning = true
+    or
+    this.getHead().regexpMatch("prefast\\s*\\(\\s*push\\s*\\)") and isWarning = false
+  }
+
+  boolean getIsWarning() { result = isWarning }
+}
+
+/** Represents a pragma pop statement. */
+class SuppressionPopPragma extends PreprocessorPragma {
+  boolean isWarning;
+
+  SuppressionPopPragma() {
+    this.getHead().regexpMatch("warning\\s*\\(\\s*pop\\s*\\)") and isWarning = true
+    or
+    this.getHead().regexpMatch("prefast\\s*\\(\\s*pop\\s*\\)") and isWarning = false
+  }
+
+  boolean getIsWarning() { result = isWarning }
+}
+
+/** Represents an area surrounded by pragma push/pops. */
+class SuppressionPushPopSegment extends Location {
+  SuppressionPushPragma push;
+  SuppressionPopPragma pop;
+  Location start;
+  Location end;
+
+  SuppressionPushPopSegment() {
+    start = this and
+    push.getLocation() = start and
+    pop.getLocation() = end and
+    pop.getFile() = push.getFile() and
+    pop.getLocation().getStartLine() >= push.getLocation().getEndLine() and
+    pop.getIsWarning() = push.getIsWarning() and
+    not exists(SuppressionPopPragma closerPop |
+      closerPop.getFile() = push.getFile() and
+      closerPop.getLocation().getStartLine() >= push.getLocation().getEndLine() and
+      closerPop.getLocation().getEndLine() < pop.getLocation().getStartLine() and
+      closerPop.getIsWarning() = push.getIsWarning()
+    )
+  }
+
+  /** Determines if a given location is in this push/pop segment. */
+  pragma[inline]
+  predicate isInPushPopSegment(Location l) {
+    l.getFile() = this.getFile() and
+    l.getStartLine() >= start.getEndLine() and
+    l.getEndLine() <= end.getStartLine()
+  }
+
+  /** Returns a disable pragma within this push/pop segment. */
+  cached
+  DisablePragma getADisablePragma() {
+    result = any(DisablePragma p | this.isInPushPopSegment(p.getLocation()))
+  }
+}


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [X] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] N/A A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.

This PR adds a library and alert-suppression query for using the existing Code Analysis suppression annotations for our queries that were ported from CA.  To run the query, it should be run as part of a suite with other rules and the results output to SARIF; the SARIF will then be annotated to indicate the issue was suppressed at the source level.  

There are a few cases related to the semantics of pragma suppression that are not yet implemented, but are called out as bugs in the test cases and to-dos in the suppression library.

As this is not a formal query, it cannot use our standard test infrastructure (attempting to run the query on its own will result in an empty SARIF file).  Instead, test cases have been added to the ExtendedDeprecatedAPIs test.  When testing this query, you should build that database and then run both DriverAlertSuppression.ql and ExtendedDeprecatedApis.ql on the database in the same command.