### PR TITLE
Extend suppression library to more cases and cleanup

### DIFF
--- a/src/drivers/general/DriverAlertSuppression.ql
+++ b/src/drivers/general/DriverAlertSuppression.ql
@@ -7,8 +7,8 @@
  * This query is a suppression query designed to identify existing PREFast-style suppressions
  * in Windows driver code and honor them through LGTM's suppression system.  It cannot be run
  * on its own.  Instead, it should be run alongside other queries; when the code has a valid
- * suppression for a given result, the output of the run will indicate that the result was 
- * suppressed in the SARIF file.
+ * suppression for a given result, the SARIF file output by the run will
+ * indicate that the result was suppressed in the code.
  * 
  * Note that at this time, these suppressions are *not* taken into consideration during
  * WHCP certification by the Static Tools Logo test.

--- a/src/drivers/general/DriverAlertSuppression.ql
+++ b/src/drivers/general/DriverAlertSuppression.ql
@@ -3,6 +3,15 @@
  * @description Suppresses alerts in Windows Drivers based on Code Analysis syntax.
  * @kind alert-suppression
  * @id cpp/windows/drivers/driver-alert-suppression
+ * 
+ * This query is a suppression query designed to identify existing PREFast-style suppressions
+ * in Windows driver code and honor them through LGTM's suppression system.  It cannot be run
+ * on its own.  Instead, it should be run alongside other queries; when the code has a valid
+ * suppression for a given result, the output of the run will indicate that the result was 
+ * suppressed in the SARIF file.
+ * 
+ * Note that at this time, these suppressions are *not* taken into consideration during
+ * WHCP certification by the Static Tools Logo test.
  */
 
 private import drivers.libraries.Suppression
@@ -10,6 +19,6 @@ private import drivers.libraries.Suppression
 from CASuppression cas, string text, string annotation, CASuppressionScope scope
 where
   text = cas.toString() and // text of suppression comment (excluding delimiters)
-  annotation = cas.makeLgtmName() // text of suppression annotation
+  annotation = cas.makeLgtmName() // annotation converted to "lgtm[rule-name]" format
   and cas.getScope() = scope // scope of suppression
 select cas, text, annotation, scope

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
@@ -6,7 +6,7 @@
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.11.5",
+        "semanticVersion" : "2.11.6",
         "rules" : [ {
           "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
           "name" : "cpp/windows/drivers/queries/extended-deprecated-apis",
@@ -39,7 +39,7 @@
       },
       "extensions" : [ {
         "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "0.1.0+10ae08b29e203859dc319a0a1eee2d7d87cd3f88",
+        "semanticVersion" : "0.1.0+94e5e84388d98059e0209f9933621a76c0dee7f1",
         "locations" : [ {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
@@ -99,7 +99,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "2ebae78f14622650:1",
+        "primaryLocationLineHash" : "82e29691df499d5d:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -127,7 +127,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "e3b86354faff5cc5:1",
+        "primaryLocationLineHash" : "a0f4009610bac07b:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -148,42 +148,14 @@
             "index" : 0
           },
           "region" : {
-            "startLine" : 42,
+            "startLine" : 43,
             "startColumn" : 5,
             "endColumn" : 11
           }
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "ef6512d2da0af59c:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 44,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "edb7b00d5c78b908:1",
+        "primaryLocationLineHash" : "969c85f34783b0c9:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -211,7 +183,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "9df002ac3942a1c8:1",
+        "primaryLocationLineHash" : "35b38347e72e53ee:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -239,35 +211,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "3c680a64917ef518:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 51,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "9a9b276cd87e28c6:1",
+        "primaryLocationLineHash" : "457c58a531c32719:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -295,7 +239,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "bbc0c7cbc3a8c61b:1",
+        "primaryLocationLineHash" : "c48f69dbca4d1e2:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -316,42 +260,14 @@
             "index" : 0
           },
           "region" : {
-            "startLine" : 55,
+            "startLine" : 57,
             "startColumn" : 5,
             "endColumn" : 11
           }
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "5774da00ce2ad9ba:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 58,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "5cf377904556a621:1",
+        "primaryLocationLineHash" : "b8199b93e64f724c:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -379,7 +295,119 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "bb482f4293b46bf5:1",
+        "primaryLocationLineHash" : "67adf17cf52f9cb0:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 63,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "37878d516b970fae:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 66,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "d24a502aa610bd2e:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 69,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "6a27d42186f1df7d:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 72,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "af4c1b7ec005cdbe:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -34,32 +34,40 @@ VOID AlertSuppressionTesting()
     PSTR src = "Testing suppression";
     char dst[100];
 
-    strcpy(dst, src); // Unsuppressed
-
-#pragma prefast(suppress : 28719)
-    strcpy(dst, src);
-#pragma prefast(suppress : 28719, "Suppression with comment")
-    strcpy(dst, src); 
-#pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment")
-    strcpy(dst, src); 
-#pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis)
-    strcpy(dst, src);
-#pragma prefast(suppress : 28719)
-#pragma prefast(suppress : 28720)
-    strcpy(dst, src);
-#pragma prefast(suppress : 28720 28719)
-    strcpy(dst, src);
-#pragma prefast(disable : 28719)
-    strcpy(dst, src); 
-#pragma prefast(push)
     strcpy(dst, src); // Intentionally unsuppressed
 
-#pragma prefast(disable : 28719)
+#pragma prefast(suppress : 28719) // Suppress a single rule
     strcpy(dst, src);
-#pragma prefast(pop)
+
+#pragma prefast(suppress : 28719, "Suppression with comment") // Suppress a rule with rationale provided
     strcpy(dst, src); 
+
+#pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment") // Suppress a rule via legacy CA name
+    strcpy(dst, src); 
+
+#pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis) // Suppress a rule via CodeQL name
+    strcpy(dst, src);
     
-#pragma prefast(suppress : 28719)
+#pragma prefast(suppress : 28719) // Suppress a rule when there is whitespace between the pragma and the result
 
     strcpy(dst, src);
+
+#pragma prefast(suppress : 28719) // Suppress a rule when there is an additional suppression between the suppress pragma and the violating code
+#pragma prefast(suppress : 28720) 
+    strcpy(dst, src);
+
+#pragma prefast(suppress : 28720 28719) // Suppress multiple rules in a single command
+    strcpy(dst, src);
+
+#pragma prefast(disable : 28719) // Suppress a rule indefinitely until the stack is pushed
+    strcpy(dst, src); 
+
+#pragma prefast(push) // Push the pragma state onto the stack, nullifying the disable command
+    strcpy(dst, src); // Intentionally unsuppressed
+
+#pragma prefast(disable : 28719) // Apply a new disable command in this stack frame
+    strcpy(dst, src);
+
+#pragma prefast(pop) // Pop the pragma stack, re-applying the original disable pragma
+    strcpy(dst, src); 
 }

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -39,9 +39,9 @@ VOID AlertSuppressionTesting()
 #pragma prefast(suppress : 28719)
     strcpy(dst, src);
 #pragma prefast(suppress : 28719, "Suppression with comment")
-    strcpy(dst, src); // BUG: REGRESSION: Lost comment support in recent changes
+    strcpy(dst, src); 
 #pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment")
-    strcpy(dst, src); // BUG: REGRESSION: Lost word-based suppression in recent changes
+    strcpy(dst, src); 
 #pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis)
     strcpy(dst, src);
 #pragma prefast(suppress : 28719)

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -46,7 +46,7 @@ VOID AlertSuppressionTesting()
     strcpy(dst, src);
 #pragma prefast(suppress : 28719)
 #pragma prefast(suppress : 28720)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
+    strcpy(dst, src);
 #pragma prefast(suppress : 28720 28719)
     strcpy(dst, src); // BUG: Should be suppressed, isn't
 #pragma prefast(disable : 28719)
@@ -58,4 +58,8 @@ VOID AlertSuppressionTesting()
     strcpy(dst, src);
 #pragma prefast(pop)
     strcpy(dst, src); // BUG: Should be suppressed, isn't
+    
+#pragma prefast(suppress : 28719)
+
+    strcpy(dst, src);
 }

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -39,9 +39,9 @@ VOID AlertSuppressionTesting()
 #pragma prefast(suppress : 28719)
     strcpy(dst, src);
 #pragma prefast(suppress : 28719, "Suppression with comment")
-    strcpy(dst, src);
+    strcpy(dst, src); // BUG: REGRESSION: Lost comment support in recent changes
 #pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment")
-    strcpy(dst, src);
+    strcpy(dst, src); // BUG: REGRESSION: Lost word-based suppression in recent changes
 #pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis)
     strcpy(dst, src);
 #pragma prefast(suppress : 28719)
@@ -50,14 +50,14 @@ VOID AlertSuppressionTesting()
 #pragma prefast(suppress : 28720 28719)
     strcpy(dst, src);
 #pragma prefast(disable : 28719)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
+    strcpy(dst, src); 
 #pragma prefast(push)
-    strcpy(dst, src); // Unsuppressed
+    strcpy(dst, src); // Intentionally unsuppressed
 
 #pragma prefast(disable : 28719)
     strcpy(dst, src);
 #pragma prefast(pop)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
+    strcpy(dst, src); 
     
 #pragma prefast(suppress : 28719)
 

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -48,7 +48,7 @@ VOID AlertSuppressionTesting()
 #pragma prefast(suppress : 28720)
     strcpy(dst, src);
 #pragma prefast(suppress : 28720 28719)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
+    strcpy(dst, src);
 #pragma prefast(disable : 28719)
     strcpy(dst, src); // BUG: Should be suppressed, isn't
 #pragma prefast(push)

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -1,9 +1,17 @@
 import cpp
 
 // Reference: https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170
-//TODO: Support pragmas that combine disable, suppress, etc. in a single line
-//TODO: Support LGTM-style comment suppression?
-/** Represents a Code Analysis-style suppression using #pragma commands. */
+
+/** Represents a Code Analysis-style suppression using #pragma commands. 
+ * 
+ * In this library we support two styles:
+ * #pragma prefast (suppress:XXXX) which suppresses rule XXXX on the following line of code, and
+ * #pragma prefast (disable:XXXX) which suppresses rule XXXX until the pragma stack is adjusted using #pragma (push/pop).
+ * 
+ * More details can be found at https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170.
+ * Please note that at present, pragma commands combining disable and suppress commands in a single line are
+ * not supported.
+*/
 abstract class CASuppression extends PreprocessorPragma {
   abstract predicate matchesRuleName(string name);
 
@@ -121,7 +129,8 @@ class CASuppressionScope extends ElementBase instanceof CASuppression {
 class SuppressPragma extends CASuppression {
   string suppressedRule;
 
-  /** The characteristic predicate for a SuppressPragma relies on a regex that matches comments of the form:
+  /**
+   * The characteristic predicate for a SuppressPragma relies on a regex that matches comments of the form:
    * [prefast/warning](suppress:[rule IDs]{, "comment"}) where the {} contents are fully optional.
    * Note that rule IDs can be in the form of raw numbers, or strings that may connect with dashes or underscores,
    * and multiple rule IDs may be specified in a single suppression.
@@ -131,12 +140,8 @@ class SuppressPragma extends CASuppression {
       any(string s |
         s =
           this.getHead()
-              .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
-              .splitAt(" ")
-        or
-        s =
-          this.getHead()
-              .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
+              .regexpCapture("(prefast|warning)\\(\\s*suppress\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)",
+                2)
               .splitAt(" ")
       )
   }
@@ -182,12 +187,8 @@ class DisablePragma extends CASuppression {
       any(string s |
         s =
           this.getHead()
-              .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
-              .splitAt(" ")
-        or
-        s =
-          this.getHead()
-              .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
+              .regexpCapture("(prefast|warning)\\(\\s*disable\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)",
+                2)
               .splitAt(" ")
       )
   }

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -121,20 +121,19 @@ class CASuppressionScope extends ElementBase instanceof CASuppression {
 class SuppressPragma extends CASuppression {
   string suppressedRule;
 
-  // TODO: Support #pragma warning(suppress:28104 28161 6001 6101) - i.e. multiple suppresses in one line
   SuppressPragma() {
     suppressedRule =
       any(string s |
-        exists(int n |
           s =
             this.getHead()
-                .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w]+)[\\s\\d\\w\\W]*\\)", n)
+                .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+                .splitAt(" ")
           or
-          suppressedRule =
+          s =
             this.getHead()
-                .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w]+)[\\s\\d\\w\\W]*\\)", n)
+                .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+                .splitAt(" ")
         )
-      )
   }
 
   pragma[inline]
@@ -172,10 +171,17 @@ class DisablePragma extends CASuppression {
 
   // TODO: Support #pragma warning(disable:28104 28161 6001 6101) - i.e. multiple rules disabled in one line
   DisablePragma() {
-    disabledRule =
-      this.getHead().regexpCapture("warning\\s*\\(\\s*disable\\s*:\\s*([\\d\\w]+)\\s*\\)", 1) or
-    disabledRule =
-      this.getHead().regexpCapture("prefast\\s*\\(\\s*disable\\s*:\\s*([\\d\\w]+)\\s*\\)", 1)
+    disabledRule = any(string s |
+      s =
+        this.getHead()
+            .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+            .splitAt(" ")
+      or
+      s =
+        this.getHead()
+            .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+            .splitAt(" ")
+    )
   }
 
   pragma[inline]

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -121,17 +121,22 @@ class CASuppressionScope extends ElementBase instanceof CASuppression {
 class SuppressPragma extends CASuppression {
   string suppressedRule;
 
+  /** The characteristic predicate for a SuppressPragma relies on a regex that matches comments of the form:
+   * [prefast/warning](suppress:[rule IDs]{, "comment"}) where the {} contents are fully optional.
+   * Note that rule IDs can be in the form of raw numbers, or strings that may connect with dashes or underscores,
+   * and multiple rule IDs may be specified in a single suppression.
+   */
   SuppressPragma() {
     suppressedRule =
       any(string s |
         s =
           this.getHead()
-              .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
               .splitAt(" ")
         or
         s =
           this.getHead()
-              .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
               .splitAt(" ")
       )
   }
@@ -172,18 +177,17 @@ class SuppressPragma extends CASuppression {
 class DisablePragma extends CASuppression {
   string disabledRule;
 
-  // TODO: Support #pragma warning(disable:28104 28161 6001 6101) - i.e. multiple rules disabled in one line
   DisablePragma() {
     disabledRule =
       any(string s |
         s =
           this.getHead()
-              .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
               .splitAt(" ")
         or
         s =
           this.getHead()
-              .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s\\\\\\p{Pd}\\p{Pc}/]+)+(,?([\\s\\w\\d\\W\\p{P}]))*\\)", 1)
               .splitAt(" ")
       )
   }

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -145,8 +145,21 @@ class SuppressPragma extends CASuppression {
 
   override predicate appliesToLocation(Location l) {
     this.getFile() = l.getFile() and
-    this.getLocation().getEndLine() + 1 = l.getStartLine()
-    // TODO: Support case where multiple suppressions are stacked on consecutive lines
+    this.getLocation().getEndLine() + this.getMinimumLocationOffset() = l.getStartLine()
+  }
+
+  /** Finds the offset (in line count) to the closest non-pragma element after this suppression. */
+  int getMinimumLocationOffset() {
+    result =
+      min(int i |
+        i > 0 and
+        exists(Locatable l |
+          l.getFile() = this.getFile() and
+          l.getLocation().getStartLine() > this.getLocation().getEndLine() and
+          not l instanceof CASuppression and
+          this.getLocation().getEndLine() + i = l.getLocation().getStartLine()
+        )
+      )
   }
 }
 

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -124,16 +124,16 @@ class SuppressPragma extends CASuppression {
   SuppressPragma() {
     suppressedRule =
       any(string s |
-          s =
-            this.getHead()
-                .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
-                .splitAt(" ")
-          or
-          s =
-            this.getHead()
-                .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
-                .splitAt(" ")
-        )
+        s =
+          this.getHead()
+              .regexpCapture("prefast\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .splitAt(" ")
+        or
+        s =
+          this.getHead()
+              .regexpCapture("warning\\(\\s*suppress\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .splitAt(" ")
+      )
   }
 
   pragma[inline]
@@ -150,7 +150,8 @@ class SuppressPragma extends CASuppression {
 
   /** Finds the offset (in line count) to the closest non-pragma element after this suppression. */
   pragma[nomagic]
-  cached int getMinimumLocationOffset() {
+  cached
+  int getMinimumLocationOffset() {
     result =
       min(int i |
         i > 0 and
@@ -173,17 +174,18 @@ class DisablePragma extends CASuppression {
 
   // TODO: Support #pragma warning(disable:28104 28161 6001 6101) - i.e. multiple rules disabled in one line
   DisablePragma() {
-    disabledRule = any(string s |
-      s =
-        this.getHead()
-            .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
-            .splitAt(" ")
-      or
-      s =
-        this.getHead()
-            .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
-            .splitAt(" ")
-    )
+    disabledRule =
+      any(string s |
+        s =
+          this.getHead()
+              .regexpCapture("prefast\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .splitAt(" ")
+        or
+        s =
+          this.getHead()
+              .regexpCapture("warning\\(\\s*disable\\s*:\\s*([\\d\\w\\s]+)+\\)", 1)
+              .splitAt(" ")
+      )
   }
 
   pragma[inline]
@@ -192,16 +194,20 @@ class DisablePragma extends CASuppression {
   pragma[inline]
   override string getRuleName() { result = disabledRule }
 
-  pragma[inline]
+  pragma[nomagic]
   override predicate appliesToLocation(Location l) {
     this.getFile() = l.getFile() and
     this.getLocation().getEndLine() <= l.getStartLine() and
     // If we're in a pragma push/pop, ensure the disable is too
-    exists(SuppressionPushPopSegment spps |
-      spps.getADisablePragma() = this and
-      spps.isInPushPopSegment(l)
+    (
+      exists(SuppressionPushPopSegment spps |
+        spps.getADisablePragma() = this and
+        spps.isInPushPopSegment(l)
+      )
+      or
+      not exists(SuppressionPushPopSegment spps | spps.getADisablePragma() = this) and
+      not exists(SuppressionPushPopSegment spps | spps.isInPushPopSegment(l))
     )
-    // TODO: Handle case where the disable is outside push/pop
   }
 }
 

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -142,13 +142,15 @@ class SuppressPragma extends CASuppression {
   pragma[inline]
   override string getRuleName() { result = suppressedRule }
 
+  pragma[nomagic]
   override predicate appliesToLocation(Location l) {
     this.getFile() = l.getFile() and
     this.getLocation().getEndLine() + this.getMinimumLocationOffset() = l.getStartLine()
   }
 
   /** Finds the offset (in line count) to the closest non-pragma element after this suppression. */
-  int getMinimumLocationOffset() {
+  pragma[nomagic]
+  cached int getMinimumLocationOffset() {
     result =
       min(int i |
         i > 0 and


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [N/A] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [N/A] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.

Updates our suppression library to cover the following cases:

- Multiple rules suppressed in a single pragma
- Multiple pragmas listed consecutively to apply to a single line
- Disable pragmas are honored outside of push/pop segments

Also adds more comments to the suppression library/query and the associated test code.

Resolves #70.