### PR TITLE
Extend suppression library to more cases and cleanup (#71)

### DIFF
--- a/src/drivers/general/DriverAlertSuppression.ql
+++ b/src/drivers/general/DriverAlertSuppression.ql
@@ -3,6 +3,15 @@
  * @description Suppresses alerts in Windows Drivers based on Code Analysis syntax.
  * @kind alert-suppression
  * @id cpp/windows/drivers/driver-alert-suppression
+ * 
+ * This query is a suppression query designed to identify existing PREFast-style suppressions
+ * in Windows driver code and honor them through LGTM's suppression system.  It cannot be run
+ * on its own.  Instead, it should be run alongside other queries; when the code has a valid
+ * suppression for a given result, the SARIF file output by the run will
+ * indicate that the result was suppressed in the code.
+ * 
+ * Note that at this time, these suppressions are *not* taken into consideration during
+ * WHCP certification by the Static Tools Logo test.
  */
 
 private import drivers.libraries.Suppression
@@ -10,6 +19,6 @@ private import drivers.libraries.Suppression
 from CASuppression cas, string text, string annotation, CASuppressionScope scope
 where
   text = cas.toString() and // text of suppression comment (excluding delimiters)
-  annotation = cas.makeLgtmName() // text of suppression annotation
+  annotation = cas.makeLgtmName() // annotation converted to "lgtm[rule-name]" format
   and cas.getScope() = scope // scope of suppression
 select cas, text, annotation, scope

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.sarif
@@ -6,7 +6,7 @@
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.11.5",
+        "semanticVersion" : "2.11.6",
         "rules" : [ {
           "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
           "name" : "cpp/windows/drivers/queries/extended-deprecated-apis",
@@ -39,7 +39,7 @@
       },
       "extensions" : [ {
         "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "0.1.0+10ae08b29e203859dc319a0a1eee2d7d87cd3f88",
+        "semanticVersion" : "0.1.0+94e5e84388d98059e0209f9933621a76c0dee7f1",
         "locations" : [ {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
@@ -99,7 +99,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "2ebae78f14622650:1",
+        "primaryLocationLineHash" : "82e29691df499d5d:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -127,7 +127,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "e3b86354faff5cc5:1",
+        "primaryLocationLineHash" : "a0f4009610bac07b:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -148,42 +148,14 @@
             "index" : 0
           },
           "region" : {
-            "startLine" : 42,
+            "startLine" : 43,
             "startColumn" : 5,
             "endColumn" : 11
           }
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "ef6512d2da0af59c:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 44,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "edb7b00d5c78b908:1",
+        "primaryLocationLineHash" : "969c85f34783b0c9:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -211,7 +183,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "9df002ac3942a1c8:1",
+        "primaryLocationLineHash" : "35b38347e72e53ee:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -239,35 +211,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "3c680a64917ef518:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 51,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "9a9b276cd87e28c6:1",
+        "primaryLocationLineHash" : "457c58a531c32719:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -295,7 +239,7 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "bbc0c7cbc3a8c61b:1",
+        "primaryLocationLineHash" : "c48f69dbca4d1e2:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -316,42 +260,14 @@
             "index" : 0
           },
           "region" : {
-            "startLine" : 55,
+            "startLine" : 57,
             "startColumn" : 5,
             "endColumn" : 11
           }
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "5774da00ce2ad9ba:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    }, {
-      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/driver_snippet.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 58,
-            "startColumn" : 5,
-            "endColumn" : 11
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "5cf377904556a621:1",
+        "primaryLocationLineHash" : "b8199b93e64f724c:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {
@@ -379,7 +295,119 @@
         }
       } ],
       "partialFingerprints" : {
-        "primaryLocationLineHash" : "bb482f4293b46bf5:1",
+        "primaryLocationLineHash" : "67adf17cf52f9cb0:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 63,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "37878d516b970fae:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 66,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "d24a502aa610bd2e:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 69,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "6a27d42186f1df7d:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/windows/drivers/queries/extended-deprecated-apis",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "strcpy is insecure and has been marked deprecated.  Replace it with one of the following safe replacements: strcpy_s, StringCbCopy, StringCbCopyEx, StringCchCopy, StringCchCopyEx, strlcpy."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/driver_snippet.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 72,
+            "startColumn" : 5,
+            "endColumn" : 11
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "af4c1b7ec005cdbe:1",
         "primaryLocationStartColumnFingerprint" : "0"
       }
     }, {

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/driver_snippet.c
@@ -34,28 +34,40 @@ VOID AlertSuppressionTesting()
     PSTR src = "Testing suppression";
     char dst[100];
 
-    strcpy(dst, src); // Unsuppressed
+    strcpy(dst, src); // Intentionally unsuppressed
 
-#pragma prefast(suppress : 28719)
+#pragma prefast(suppress : 28719) // Suppress a single rule
     strcpy(dst, src);
-#pragma prefast(suppress : 28719, "Suppression with comment")
-    strcpy(dst, src);
-#pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment")
-    strcpy(dst, src);
-#pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis)
-    strcpy(dst, src);
-#pragma prefast(suppress : 28719)
-#pragma prefast(suppress : 28720)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
-#pragma prefast(suppress : 28720 28719)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
-#pragma prefast(disable : 28719)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
-#pragma prefast(push)
-    strcpy(dst, src); // Unsuppressed
 
-#pragma prefast(disable : 28719)
+#pragma prefast(suppress : 28719, "Suppression with comment") // Suppress a rule with rationale provided
+    strcpy(dst, src); 
+
+#pragma prefast(suppress : __WARNING_BANNED_API_USAGE, "Suppression with name and comment") // Suppress a rule via legacy CA name
+    strcpy(dst, src); 
+
+#pragma prefast(suppress : cpp/windows/drivers/queries/extended-deprecated-apis) // Suppress a rule via CodeQL name
     strcpy(dst, src);
-#pragma prefast(pop)
-    strcpy(dst, src); // BUG: Should be suppressed, isn't
+    
+#pragma prefast(suppress : 28719) // Suppress a rule when there is whitespace between the pragma and the result
+
+    strcpy(dst, src);
+
+#pragma prefast(suppress : 28719) // Suppress a rule when there is an additional suppression between the suppress pragma and the violating code
+#pragma prefast(suppress : 28720) 
+    strcpy(dst, src);
+
+#pragma prefast(suppress : 28720 28719) // Suppress multiple rules in a single command
+    strcpy(dst, src);
+
+#pragma prefast(disable : 28719) // Suppress a rule indefinitely until the stack is pushed
+    strcpy(dst, src); 
+
+#pragma prefast(push) // Push the pragma state onto the stack, nullifying the disable command
+    strcpy(dst, src); // Intentionally unsuppressed
+
+#pragma prefast(disable : 28719) // Apply a new disable command in this stack frame
+    strcpy(dst, src);
+
+#pragma prefast(pop) // Pop the pragma stack, re-applying the original disable pragma
+    strcpy(dst, src); 
 }


### PR DESCRIPTION
* Add support for stacked suppressions + empty lines between

* Allow multiple rules in one suppression

* Use cache + nomagic to improve perf.

* Missed updating a line in test code

* Support disable outside of push/pop

* Fix support for comments in suppression pragmas

* Clean up test code and add more comments

* Clarify some wording

## Checklist for Pull Requests

- [ ] Description is filled out.
- [ ] Only one query or related query group is in this pull request.
- [ ] The version number on changed queries has been increased via the `@version` comment in the file header.
- [ ] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [ ] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [ ] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.