### PR TITLE
Update suppression library to use new query IDs.

### DIFF
--- a/src/drivers/general/queries/IrqlTooHigh/IrqlTooHigh.ql
+++ b/src/drivers/general/queries/IrqlTooHigh/IrqlTooHigh.ql
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 /**
  * @id cpp/drivers/irql-too-high
- * @name IRQL too high (C28120)
+ * @name IRQL too high (C28121)
  * @description A function annotated with IRQL requirements was called at an IRQL too high for the requirements.
  * @platform Desktop
  * @security.severity Low
@@ -10,7 +10,7 @@
  * @impact Exploitable Design
  * @repro.text The following function call is taking place at an IRQL too high for what the call target is annotated as.
  * @owner.email sdat@microsoft.com
- * @opaqueid CQLD-C28120
+ * @opaqueid CQLD-C28121
  * @kind problem
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlTooHigh/IrqlTooHigh.sarif
+++ b/src/drivers/general/queries/IrqlTooHigh/IrqlTooHigh.sarif
@@ -6,7 +6,7 @@
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.14.4",
+        "semanticVersion" : "2.15.4",
         "notifications" : [ {
           "id" : "cpp/baseline/expected-extracted-files",
           "name" : "cpp/baseline/expected-extracted-files",
@@ -27,7 +27,7 @@
           "id" : "cpp/drivers/irql-too-high",
           "name" : "cpp/drivers/irql-too-high",
           "shortDescription" : {
-            "text" : "IRQL too high (C28120)"
+            "text" : "IRQL too high (C28121)"
           },
           "fullDescription" : {
             "text" : "A function annotated with IRQL requirements was called at an IRQL too high for the requirements."
@@ -43,8 +43,8 @@
             "id" : "cpp/drivers/irql-too-high",
             "impact" : "Exploitable Design",
             "kind" : "problem",
-            "name" : "IRQL too high (C28120)",
-            "opaqueid" : "CQLD-C28120",
+            "name" : "IRQL too high (C28121)",
+            "opaqueid" : "CQLD-C28121",
             "owner.email" : "sdat@microsoft.com",
             "platform" : "Desktop",
             "precision" : "medium",
@@ -58,7 +58,7 @@
       },
       "extensions" : [ {
         "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "0.2.0+4842fd4116871d3b47eede85c2c4497b43c34d57",
+        "semanticVersion" : "1.1.0+2affc3c634804dac7504a483a378cc9ba22a0f0b",
         "locations" : [ {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {

--- a/src/drivers/general/queries/IrqlTooLow/IrqlTooLow.ql
+++ b/src/drivers/general/queries/IrqlTooLow/IrqlTooLow.ql
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 /**
  * @id cpp/drivers/irql-too-low
- * @name IRQL too low (C28121)
+ * @name IRQL too low (C28120)
  * @description A function annotated with IRQL requirements was called at an IRQL too low for the requirements.
  * @platform Desktop
  * @security.severity Low
@@ -10,7 +10,7 @@
  * @impact Exploitable Design
  * @repro.text The following function call is taking place at an IRQL too low for what the call target is annotated as.
  * @owner.email sdat@microsoft.com
- * @opaqueid CQLD-C28121
+ * @opaqueid CQLD-C28120
  * @kind problem
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlTooLow/IrqlTooLow.sarif
+++ b/src/drivers/general/queries/IrqlTooLow/IrqlTooLow.sarif
@@ -6,7 +6,7 @@
       "driver" : {
         "name" : "CodeQL",
         "organization" : "GitHub",
-        "semanticVersion" : "2.14.4",
+        "semanticVersion" : "2.15.4",
         "notifications" : [ {
           "id" : "cpp/baseline/expected-extracted-files",
           "name" : "cpp/baseline/expected-extracted-files",
@@ -27,7 +27,7 @@
           "id" : "cpp/drivers/irql-too-low",
           "name" : "cpp/drivers/irql-too-low",
           "shortDescription" : {
-            "text" : "IRQL too low (C28121)"
+            "text" : "IRQL too low (C28120)"
           },
           "fullDescription" : {
             "text" : "A function annotated with IRQL requirements was called at an IRQL too low for the requirements."
@@ -43,8 +43,8 @@
             "id" : "cpp/drivers/irql-too-low",
             "impact" : "Exploitable Design",
             "kind" : "problem",
-            "name" : "IRQL too low (C28121)",
-            "opaqueid" : "CQLD-C28121",
+            "name" : "IRQL too low (C28120)",
+            "opaqueid" : "CQLD-C28120",
             "owner.email" : "sdat@microsoft.com",
             "platform" : "Desktop",
             "precision" : "medium",
@@ -58,7 +58,7 @@
       },
       "extensions" : [ {
         "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "0.2.0+4842fd4116871d3b47eede85c2c4497b43c34d57",
+        "semanticVersion" : "1.1.0+2affc3c634804dac7504a483a378cc9ba22a0f0b",
         "locations" : [ {
           "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {

--- a/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.ql
+++ b/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.ql
@@ -10,7 +10,7 @@
  * @impact Insecure Coding Practice
  * @repro.text
  * @owner.email: sdat@microsoft.com
- * @opaqueid CQLD-C28158
+ * @opaqueid CQLD-D0007
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.sarif
+++ b/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.sarif
@@ -44,12 +44,12 @@
             "impact" : "Insecure Coding Practice",
             "kind" : "problem",
             "name" : "Incorrect Role Type Use",
-            "opaqueid" : "CQLD-C28158",
+            "opaqueid" : "CQLD-D0007",
             "owner.email:" : "sdat@microsoft.com",
             "platform" : "Desktop",
             "precision" : "medium",
             "problem.severity" : "warning",
-            "query-version" : "v1",
+            "query-version" : "v2",
             "repro.text" : "",
             "scope" : "domainspecific"
           }
@@ -57,14 +57,14 @@
       },
       "extensions" : [ {
         "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "1.0.12+54db165bcee31f7827c56bf2bb9a408d8a4db4fe",
+        "semanticVersion" : "1.1.0+2affc3c634804dac7504a483a378cc9ba22a0f0b",
         "locations" : [ {
-          "uri" : "file:///C:/codeql-home/WDDST/src/",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/",
           "description" : {
             "text" : "The QL pack root directory."
           }
         }, {
-          "uri" : "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+          "uri" : "file:///C:/codeql-home/Windows-Driver-Developer-Supplemental-Tools/src/qlpack.yml",
           "description" : {
             "text" : "The QL pack definition file."
           }
@@ -76,9 +76,9 @@
         "locations" : [ {
           "physicalLocation" : {
             "artifactLocation" : {
-              "uri" : "driver/driver_snippet.c",
+              "uri" : "driver/fail_driver1.c",
               "uriBaseId" : "%SRCROOT%",
-              "index" : 0
+              "index" : 1
             }
           }
         } ],
@@ -99,9 +99,9 @@
         "locations" : [ {
           "physicalLocation" : {
             "artifactLocation" : {
-              "uri" : "driver/fail_driver1.c",
+              "uri" : "driver/driver_snippet.c",
               "uriBaseId" : "%SRCROOT%",
-              "index" : 1
+              "index" : 0
             }
           }
         } ],

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -1,17 +1,17 @@
 import cpp
 
 // Reference: https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170
-
-/** Represents a Code Analysis-style suppression using #pragma commands. 
- * 
+/**
+ * Represents a Code Analysis-style suppression using #pragma commands.
+ *
  * In this library we support two styles:
  * #pragma prefast (suppress:XXXX) which suppresses rule XXXX on the following line of code, and
  * #pragma prefast (disable:XXXX) which suppresses rule XXXX until the pragma stack is adjusted using #pragma (push/pop).
- * 
+ *
  * More details can be found at https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170.
  * Please note that at present, pragma commands combining disable and suppress commands in a single line are
  * not supported.
-*/
+ */
 abstract class CASuppression extends PreprocessorPragma {
   abstract predicate matchesRuleName(string name);
 
@@ -38,11 +38,7 @@ abstract class CASuppression extends PreprocessorPragma {
     or
     this.getRuleName() = any(["__WARNING_UNHELPFUL_TAG", "28147"]) and
     result =
-      any([
-            "lgtm[cpp/drivers/default-pool-tag]",
-            "lgtm[cpp/drivers/default-pool-tag-extended]"
-          ]
-      )
+      any(["lgtm[cpp/drivers/default-pool-tag]", "lgtm[cpp/drivers/default-pool-tag-extended]"])
     or
     this.getRuleName() = any(["__WARNING_IRQL_NOT_SET", "28158"]) and
     result = "lgtm[cpp/drivers/irql-not-saved]"
@@ -66,37 +62,37 @@ abstract class CASuppression extends PreprocessorPragma {
     result = "lgtm[cpp/portedqueries/irq-too-high]"
     or
     this.getRuleName() = any(["__WARNING_FUNCTION_ASSIGNMENT", "28128"]) and
-    result = "lgtm[cpp/windows/drivers/queries/illegal-field-access]"
+    result = "lgtm[cpp/drivers/illegal-field-access]"
     or
     this.getRuleName() = any(["__WARNING_INACCESSIBLE_MEMBER", "28175"]) and
-    result = "lgtm[cpp/windows/drivers/queries/illegal-field-access-2]"
+    result = "lgtm[cpp/drivers/illegal-field-access-2]"
     or
     this.getRuleName() = any(["__WARNING_READ_ONLY_MEMBER", "28176"]) and
-    result = "lgtm[cpp/windows/drivers/queries/illegal-field-write]"
+    result = "lgtm[cpp/drivers/illegal-field-write]"
     or
     this.getRuleName() = any(["__WARNING_INIT_NOT_CLEARED", "28152"]) and
-    result = "lgtm[cpp/windows/drivers/queries/init-not-cleared]"
+    result = "lgtm[cpp/drivers/init-not-cleared]"
     or
     this.getRuleName() = any(["__WARNING_KE_WAIT_LOCAL", "28135"]) and
     result = "lgtm[cpp/drivers/kewaitlocal-requires-kernel-mode]"
     or
     this.getRuleName() = any(["__WARNING_MULTIPLE_PAGED_CODE", "28171"]) and
-    result = "lgtm[cpp/portedqueries/multiple-paged-code]"
+    result = "lgtm[cpp/drivers/multiple-paged-code]"
     or
     this.getRuleName() = any(["__WARNING_NO_PAGED_CODE", "28170"]) and
-    result = "lgtm[cpp/portedqueries/no-paged-code]"
+    result = "lgtm[cpp/drivers/no-paged-code]"
     or
     this.getRuleName() = any(["__WARNING_NO_PAGING_SEGMENT", "28172"]) and
-    result = "lgtm[cpp/portedqueries/no-paging-segment]"
+    result = "lgtm[cpp/drivers/no-paging-segment]"
     or
     this.getRuleName() = any(["__WARNING_OBJ_REFERENCE_MODE", "28126"]) and
-    result = "lgtm[cpp/windows/drivers/queries/ob-reference-mode]"
+    result = "lgtm[cpp/drivers/ob-reference-mode]"
     or
     this.getRuleName() = any(["__WARNING_MODIFYING_MDL", "28145"]) and
-    result = "lgtm[cpp/windows/drivers/queries/opaquemdlwrite]"
+    result = "lgtm[cpp/drivers/opaque-mdl-write]"
     or
     this.getRuleName() = any(["__WARNING_PENDING_STATUS_ERROR", "28143"]) and
-    result = "lgtm[cpp/portedqueries/pending-status-error]"
+    result = "lgtm[cpp/drivers/pending-status-error]"
     or
     this.getRuleName() =
       any(["__WARNING_DISPATCH_MISMATCH", "28168", "__WARNING_DISPATCH_MISSING", "28169"]) and
@@ -108,8 +104,23 @@ abstract class CASuppression extends PreprocessorPragma {
     this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_LOW", "28124"]) and
     result = "lgtm[cpp/drivers/irql-set-too-low]"
     or
-    this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_HIGH", "28121"]) and
-    result = "lgtm[cpp/drivers/irql-too-high]" //TODO fix opaqueid for this query
+    this.getRuleName() = any(["__WARNING_IRQ_TOO_HIGH", "28121"]) and
+    result = "lgtm[cpp/drivers/irql-too-high]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
+    result = "lgtm[cpp/drivers/irql-too-low]"
+    or
+    this.getRuleName() = any(["__WARNING_INTERLOCKEDDECREMENT_MISUSE1", "28616"]) and
+    result = "lgtm[cpp/drivers/multithreaded-av-condition]"
+    or
+    this.getRuleName() = any(["__WARNING_POOL_TAG", "28134"]) and
+    result = "lgtm[cpp/drivers/pool-tag-integral]"
+    or
+    this.getRuleName() = any(["__WARNING_PROTOTYPE_MISMATCH", "28127"]) and
+    result = "lgtm[cpp/drivers/routine-function-type-not-expected]"
+    or
+    this.getRuleName() = any(["__WARNING_STRSAFE_H", "28146"]) and
+    result = "lgtm[cpp/drivers/str-safe]"
     or
     result = "lgtm[" + this.getRuleName() + "]"
   }

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -34,13 +34,13 @@ abstract class CASuppression extends PreprocessorPragma {
             "__WARNING_BANNED_API_USAGE_LSTRLEN", "28750"
           ]
       ) and
-    result = "lgtm[cpp/windows/drivers/queries/extended-deprecated-apis]"
+    result = "lgtm[cpp/drivers/extended-deprecated-apis]"
     or
     this.getRuleName() = any(["__WARNING_UNHELPFUL_TAG", "28147"]) and
     result =
       any([
-            "lgtm[cpp/windows/drivers/queries/default-pool-tag]",
-            "lgtm[cpp/windows/drivers/queries/default-pool-tag-extended]"
+            "lgtm[cpp/drivers/default-pool-tag]",
+            "lgtm[cpp/drivers/default-pool-tag-extended]"
           ]
       )
     or
@@ -57,7 +57,7 @@ abstract class CASuppression extends PreprocessorPragma {
     result = "lgtm[cpp/portedqueries/str-safe]"
     or
     this.getRuleName() = any(["__WARNING_MUST_USE", "28193"]) and
-    result = "lgtm[cpp/portedqueries/examined-value]"
+    result = "lgtm[cpp/drivers/examined-value]"
     or
     this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
     result = "lgtm[cpp/portedqueries/irq-too-low]"
@@ -101,6 +101,15 @@ abstract class CASuppression extends PreprocessorPragma {
     this.getRuleName() =
       any(["__WARNING_DISPATCH_MISMATCH", "28168", "__WARNING_DISPATCH_MISSING", "28169"]) and
     result = "lgtm[cpp/portedqueries/wrong-dispatch-table-assignment]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_HIGH", "28150"]) and
+    result = "lgtm[cpp/drivers/irql-set-too-high]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_LOW", "28124"]) and
+    result = "lgtm[cpp/drivers/irql-set-too-low]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_HIGH", "28121"]) and
+    result = "lgtm[cpp/drivers/irql-too-high]" //TODO fix opaqueid for this query
     or
     result = "lgtm[" + this.getRuleName() + "]"
   }

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -47,19 +47,19 @@ abstract class CASuppression extends PreprocessorPragma {
     result = "lgtm[cpp/drivers/irql-not-used]"
     or
     this.getRuleName() = any(["__WARNING_POOL_TAG", "28134"]) and
-    result = "lgtm[cpp/windows/drivers/queries/pool-tag-integral]"
+    result = "lgtm[cpp/drivers/pool-tag-integral]"
     or
     this.getRuleName() = any(["__WARNING_STRSAFE_H", "28146"]) and
-    result = "lgtm[cpp/portedqueries/str-safe]"
+    result = "lgtm[cpp/drivers/str-safe]"
     or
     this.getRuleName() = any(["__WARNING_MUST_USE", "28193"]) and
     result = "lgtm[cpp/drivers/examined-value]"
     or
-    this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
-    result = "lgtm[cpp/portedqueries/irq-too-low]"
-    or
     this.getRuleName() = any(["__WARNING_IRQ_TOO_HIGH", "28121"]) and
-    result = "lgtm[cpp/portedqueries/irq-too-high]"
+    result = "lgtm[cpp/drivers/irql-too-high]"
+    or
+    this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
+    result = "lgtm[cpp/drivers/irql-too-low]"
     or
     this.getRuleName() = any(["__WARNING_FUNCTION_ASSIGNMENT", "28128"]) and
     result = "lgtm[cpp/drivers/illegal-field-access]"
@@ -96,7 +96,7 @@ abstract class CASuppression extends PreprocessorPragma {
     or
     this.getRuleName() =
       any(["__WARNING_DISPATCH_MISMATCH", "28168", "__WARNING_DISPATCH_MISSING", "28169"]) and
-    result = "lgtm[cpp/portedqueries/wrong-dispatch-table-assignment]"
+    result = "lgtm[cpp/drivers/wrong-dispatch-table-assignment]"
     or
     this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_HIGH", "28150"]) and
     result = "lgtm[cpp/drivers/irql-set-too-high]"
@@ -104,23 +104,11 @@ abstract class CASuppression extends PreprocessorPragma {
     this.getRuleName() = any(["__WARNING_IRQ_SET_TOO_LOW", "28124"]) and
     result = "lgtm[cpp/drivers/irql-set-too-low]"
     or
-    this.getRuleName() = any(["__WARNING_IRQ_TOO_HIGH", "28121"]) and
-    result = "lgtm[cpp/drivers/irql-too-high]"
-    or
-    this.getRuleName() = any(["__WARNING_IRQ_TOO_LOW", "28120"]) and
-    result = "lgtm[cpp/drivers/irql-too-low]"
-    or
     this.getRuleName() = any(["__WARNING_INTERLOCKEDDECREMENT_MISUSE1", "28616"]) and
     result = "lgtm[cpp/drivers/multithreaded-av-condition]"
     or
-    this.getRuleName() = any(["__WARNING_POOL_TAG", "28134"]) and
-    result = "lgtm[cpp/drivers/pool-tag-integral]"
-    or
     this.getRuleName() = any(["__WARNING_PROTOTYPE_MISMATCH", "28127"]) and
     result = "lgtm[cpp/drivers/routine-function-type-not-expected]"
-    or
-    this.getRuleName() = any(["__WARNING_STRSAFE_H", "28146"]) and
-    result = "lgtm[cpp/drivers/str-safe]"
     or
     result = "lgtm[" + this.getRuleName() + "]"
   }


### PR DESCRIPTION
The suppression library needed to be updated to use our new query ID layouts (from release preparation) and add missing entries.  This also fixes the opaque IDs used for a few queries that didn't match the CA equivalents (or had no CA equivalent in one case.)

## Checklist for Pull Requests

- [X] Description is filled out.
- [X] Only one query or related query group is in this pull request.
- [N/A] The version number on changed queries has been increased via the `@version` comment in the file header.
- [X] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [X] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [X] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.