### PR TITLE
IrqlLoweredImproperly: Codeql port of c28141

### DIFF
--- a/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.qhelp
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.qhelp
@@ -1,0 +1,42 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+		The argument causes the IRQ Level to be set below the current IRQL, and this function cannot be used for that purpose
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+		A function call that lowers the IRQL at which a caller is executing is being used inappropriately. Typically, the function call lowers the IRQL as part of a more general routine or is intended to raise the caller's IRQL.		
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			The following code example elicits this warning.
+		</p>
+		<sample language="c"> <![CDATA[
+			KeRaiseIrql(DISPATCH_LEVEL, &OldIrql);
+			KeRaiseIrql(PASSIVE_LEVEL, &OldIrql);
+		}]]>
+		</sample>
+		<p>
+			The following code example avoids this warning.
+		</p>
+		<sample language="c"> <![CDATA[
+			KeRaiseIrql(DISPATCH_LEVEL, &OldIrql);
+			KeLowerIrql(OldIrql);
+		}]]>
+		</sample>
+	</example>
+	<semmleNotes>
+		<p>
+		</p>
+	</semmleNotes>
+	<references>
+		<li>
+			<a href="https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28141-argument-lowers-irq-level">
+				C28141
+			</a>
+		</li>
+	</references>
+</qhelp>

--- a/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.ql
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.ql
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * @id cpp/drivers/irql-lowered-improperly
+ * @kind problem
+ * @name IRQL Lowered Improperly
+ * @description A function being called changes the IRQL to below the current IRQL, and the function is not intended for that purpose.
+ * @platform Desktop
+ * @feature.area Multiple
+ * @impact Insecure Coding Practice
+ * @repro.text
+ * @owner.email: sdat@microsoft.com
+ * @opaqueid CQLD-C28141
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ * @scope domainspecific
+ * @query-version v1
+ */
+
+import cpp
+import drivers.libraries.Irql
+
+from KeRaiseIrqlCall call, ControlFlowNode prior, int irqlRequirement
+where
+  prior = call.getAPredecessor() and
+  irqlRequirement = call.getIrqlLevel() and
+  irqlRequirement != -1 and
+  irqlRequirement < min(getPotentialExitIrqlAtCfn(prior))
+select call,"$@: The function being called changes the IRQL to below the current IRQL, and the function is not intended for that purpose.",
+ call, call.toString()

--- a/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.sarif
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.sarif
@@ -1,0 +1,199 @@
+{
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
+  "version" : "2.1.0",
+  "runs" : [ {
+    "tool" : {
+      "driver" : {
+        "name" : "CodeQL",
+        "organization" : "GitHub",
+        "semanticVersion" : "2.15.4",
+        "notifications" : [ {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "name" : "cpp/baseline/expected-extracted-files",
+          "shortDescription" : {
+            "text" : "Expected extracted files"
+          },
+          "fullDescription" : {
+            "text" : "Files appearing in the source archive that are expected to be extracted."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "expected-extracted-files", "telemetry" ]
+          }
+        } ],
+        "rules" : [ {
+          "id" : "cpp/drivers/TODO",
+          "name" : "cpp/drivers/TODO",
+          "shortDescription" : {
+            "text" : "TODO"
+          },
+          "fullDescription" : {
+            "text" : "TODO"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "correctness" ],
+            "description" : "TODO",
+            "feature.area" : "Multiple",
+            "id" : "cpp/drivers/TODO",
+            "impact" : "Insecure Coding Practice",
+            "kind" : "problem",
+            "name" : "TODO",
+            "opaqueid" : "CQLD-TODO",
+            "owner.email:" : "sdat@microsoft.com",
+            "platform" : "Desktop",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "query-version" : "v1",
+            "repro.text" : "",
+            "scope" : "domainspecific"
+          }
+        } ]
+      },
+      "extensions" : [ {
+        "name" : "microsoft/windows-drivers",
+        "semanticVersion" : "1.0.13+4cf80ade609037becb8999823de45e08bd818a20",
+        "locations" : [ {
+          "uri" : "file:///C:/codeql-home/WDDST/src/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      } ]
+    },
+    "invocations" : [ {
+      "toolExecutionNotifications" : [ {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/driver_snippet.c",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 1
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/fail_driver1.c",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 0
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/fail_driver1.h",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 2
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      } ],
+      "executionSuccessful" : true
+    } ],
+    "artifacts" : [ {
+      "location" : {
+        "uri" : "driver/fail_driver1.c",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 0
+      }
+    }, {
+      "location" : {
+        "uri" : "driver/driver_snippet.c",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 1
+      }
+    }, {
+      "location" : {
+        "uri" : "driver/fail_driver1.h",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 2
+      }
+    } ],
+    "results" : [ {
+      "ruleId" : "cpp/drivers/TODO",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/drivers/TODO",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "TODO"
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/fail_driver1.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 56,
+            "endColumn" : 12
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "60c6386a5ee58eb6:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    } ],
+    "columnKind" : "utf16CodeUnits",
+    "properties" : {
+      "semmle.formatSpecifier" : "sarifv2.1.0"
+    }
+  } ]
+}

--- a/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.sarif
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.sarif
@@ -1,199 +1,338 @@
 {
-  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
-  "version" : "2.1.0",
-  "runs" : [ {
-    "tool" : {
-      "driver" : {
-        "name" : "CodeQL",
-        "organization" : "GitHub",
-        "semanticVersion" : "2.15.4",
-        "notifications" : [ {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "name" : "cpp/baseline/expected-extracted-files",
-          "shortDescription" : {
-            "text" : "Expected extracted files"
-          },
-          "fullDescription" : {
-            "text" : "Files appearing in the source archive that are expected to be extracted."
-          },
-          "defaultConfiguration" : {
-            "enabled" : true
-          },
-          "properties" : {
-            "tags" : [ "expected-extracted-files", "telemetry" ]
-          }
-        } ],
-        "rules" : [ {
-          "id" : "cpp/drivers/TODO",
-          "name" : "cpp/drivers/TODO",
-          "shortDescription" : {
-            "text" : "TODO"
-          },
-          "fullDescription" : {
-            "text" : "TODO"
-          },
-          "defaultConfiguration" : {
-            "enabled" : true,
-            "level" : "warning"
-          },
-          "properties" : {
-            "tags" : [ "correctness" ],
-            "description" : "TODO",
-            "feature.area" : "Multiple",
-            "id" : "cpp/drivers/TODO",
-            "impact" : "Insecure Coding Practice",
-            "kind" : "problem",
-            "name" : "TODO",
-            "opaqueid" : "CQLD-TODO",
-            "owner.email:" : "sdat@microsoft.com",
-            "platform" : "Desktop",
-            "precision" : "medium",
-            "problem.severity" : "warning",
-            "query-version" : "v1",
-            "repro.text" : "",
-            "scope" : "domainspecific"
-          }
-        } ]
-      },
-      "extensions" : [ {
-        "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "1.0.13+4cf80ade609037becb8999823de45e08bd818a20",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/WDDST/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/WDDST/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      } ]
-    },
-    "invocations" : [ {
-      "toolExecutionNotifications" : [ {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/driver_snippet.c",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 1
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "CodeQL",
+                    "organization": "GitHub",
+                    "semanticVersion": "2.20.3",
+                    "notifications": [
+                        {
+                            "id": "cpp/baseline/expected-extracted-files",
+                            "name": "cpp/baseline/expected-extracted-files",
+                            "shortDescription": {
+                                "text": "Expected extracted files"
+                            },
+                            "fullDescription": {
+                                "text": "Files appearing in the source archive that are expected to be extracted."
+                            },
+                            "defaultConfiguration": {
+                                "enabled": true
+                            },
+                            "properties": {
+                                "tags": [
+                                    "expected-extracted-files",
+                                    "telemetry"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "cpp/extractor/summary",
+                            "name": "cpp/extractor/summary",
+                            "shortDescription": {
+                                "text": "C++ extractor telemetry"
+                            },
+                            "fullDescription": {
+                                "text": "C++ extractor telemetry"
+                            },
+                            "defaultConfiguration": {
+                                "enabled": true
+                            }
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "id": "cpp/drivers/irql-lowered-improperly",
+                            "name": "cpp/drivers/irql-lowered-improperly",
+                            "shortDescription": {
+                                "text": "IRQL Lowered Improperly"
+                            },
+                            "fullDescription": {
+                                "text": "A function being called changes the IRQL to below the current IRQL, and the function is not intended for that purpose."
+                            },
+                            "defaultConfiguration": {
+                                "enabled": true,
+                                "level": "warning"
+                            },
+                            "properties": {
+                                "tags": [
+                                    "correctness"
+                                ],
+                                "description": "A function being called changes the IRQL to below the current IRQL, and the function is not intended for that purpose.",
+                                "feature.area": "Multiple",
+                                "id": "cpp/drivers/irql-lowered-improperly",
+                                "impact": "Insecure Coding Practice",
+                                "kind": "problem",
+                                "name": "IRQL Lowered Improperly",
+                                "opaqueid": "CQLD-C28141",
+                                "owner.email:": "sdat@microsoft.com",
+                                "platform": "Desktop",
+                                "precision": "medium",
+                                "problem.severity": "warning",
+                                "query-version": "v1",
+                                "repro.text": "",
+                                "scope": "domainspecific"
+                            }
+                        }
+                    ]
+                },
+                "extensions": [
+                    {
+                        "name": "microsoft/windows-drivers",
+                        "semanticVersion": "1.3.0+a9c818955ea6a723328a7e157691b69535d9b4d0",
+                        "locations": [
+                            {
+                                "uri": "file:///C:/codeql-home/WDDST/src/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "CodeQL/LocalPackRoot"
+                                    ]
+                                }
+                            },
+                            {
+                                "uri": "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "CodeQL/LocalPackDefinitionFile"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/cpp-all",
+                        "semanticVersion": "3.1.0+d42788844f7ec0a6b9832140313cc2318e513987",
+                        "locations": [
+                            {
+                                "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "CodeQL/LocalPackRoot"
+                                    ]
+                                }
+                            },
+                            {
+                                "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "CodeQL/LocalPackDefinitionFile"
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "invocations": [
+                {
+                    "toolExecutionNotifications": [
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "driver/driver_snippet.c",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "cpp/baseline/expected-extracted-files",
+                                "index": 0
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "driver/fail_driver1.h",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "cpp/baseline/expected-extracted-files",
+                                "index": 0
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "driver/fail_driver1.c",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 2
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "cpp/baseline/expected-extracted-files",
+                                "index": 0
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "message": {
+                                "text": "Internal telemetry for the C++ extractor.\n\nNo action needed.",
+                                "markdown": "Internal telemetry for the C++ extractor.\n\nNo action needed."
+                            },
+                            "level": "note",
+                            "timeUtc": "2025-01-31T02:39:27.052464300Z",
+                            "descriptor": {
+                                "id": "cpp/extractor/summary",
+                                "index": 1
+                            },
+                            "properties": {
+                                "attributes": {
+                                    "cache-hits": 0,
+                                    "cache-misses": 1,
+                                    "compilers": [
+                                        {
+                                            "program": "cl",
+                                            "version": "Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34436 for x64"
+                                        }
+                                    ],
+                                    "extractor-failures": 1,
+                                    "extractor-successes": 0,
+                                    "trap-caching": "disabled"
+                                },
+                                "visibility": {
+                                    "statusPage": false,
+                                    "telemetry": true
+                                }
+                            }
+                        }
+                    ],
+                    "executionSuccessful": true
+                }
+            ],
+            "artifacts": [
+                {
+                    "location": {
+                        "uri": "driver/driver_snippet.c",
+                        "uriBaseId": "%SRCROOT%",
+                        "index": 0
+                    }
+                },
+                {
+                    "location": {
+                        "uri": "driver/fail_driver1.h",
+                        "uriBaseId": "%SRCROOT%",
+                        "index": 1
+                    }
+                },
+                {
+                    "location": {
+                        "uri": "driver/fail_driver1.c",
+                        "uriBaseId": "%SRCROOT%",
+                        "index": 2
+                    }
+                }
+            ],
+            "results": [
+                {
+                    "ruleId": "cpp/drivers/irql-lowered-improperly",
+                    "ruleIndex": 0,
+                    "rule": {
+                        "id": "cpp/drivers/irql-lowered-improperly",
+                        "index": 0
+                    },
+                    "message": {
+                        "text": "[call to KfRaiseIrql](1): The function being called changes the IRQL to below the current IRQL, and the function is not intended for that purpose."
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "driver/driver_snippet.c",
+                                    "uriBaseId": "%SRCROOT%",
+                                    "index": 0
+                                },
+                                "region": {
+                                    "startLine": 21,
+                                    "startColumn": 5,
+                                    "endColumn": 41
+                                }
+                            }
+                        }
+                    ],
+                    "partialFingerprints": {
+                        "primaryLocationLineHash": "8458b7bb75b39595:1",
+                        "primaryLocationStartColumnFingerprint": "0"
+                    },
+                    "relatedLocations": [
+                        {
+                            "id": 1,
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "driver/driver_snippet.c",
+                                    "uriBaseId": "%SRCROOT%",
+                                    "index": 0
+                                },
+                                "region": {
+                                    "startLine": 21,
+                                    "startColumn": 5,
+                                    "endColumn": 41
+                                }
+                            },
+                            "message": {
+                                "text": "call to KfRaiseIrql"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "columnKind": "utf16CodeUnits",
+            "properties": {
+                "semmle.formatSpecifier": "sarifv2.1.0"
             }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
         }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/fail_driver1.c",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 0
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
-        }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/fail_driver1.h",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 2
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
-        }
-      } ],
-      "executionSuccessful" : true
-    } ],
-    "artifacts" : [ {
-      "location" : {
-        "uri" : "driver/fail_driver1.c",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 0
-      }
-    }, {
-      "location" : {
-        "uri" : "driver/driver_snippet.c",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 1
-      }
-    }, {
-      "location" : {
-        "uri" : "driver/fail_driver1.h",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 2
-      }
-    } ],
-    "results" : [ {
-      "ruleId" : "cpp/drivers/TODO",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/drivers/TODO",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "TODO"
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/fail_driver1.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 56,
-            "endColumn" : 12
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "60c6386a5ee58eb6:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    } ],
-    "columnKind" : "utf16CodeUnits",
-    "properties" : {
-      "semmle.formatSpecifier" : "sarifv2.1.0"
-    }
-  } ]
+    ]
 }

--- a/src/drivers/general/queries/IrqlLoweredImproperly/driver_snippet.c
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/driver_snippet.c
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// driver_snippet.c
+//
+
+#define SET_DISPATCH 1
+
+// Template. Not called in this test.
+void top_level_call() {}
+
+#include <wdm.h>
+
+/*
+ */
+_IRQL_raises_(DISPATCH_LEVEL)
+    VOID IrqlRaiseLevelExplicit_fail(void)
+{
+    KIRQL oldIRQL;
+    KeRaiseIrql(DISPATCH_LEVEL, &oldIRQL);
+    KeRaiseIrql(PASSIVE_LEVEL, &oldIRQL); // raise the IRQL to PASSIVE_LEVEL, which is lower than DISPATCH_LEVEL
+}
+/*
+Function can be called to raise the IRQL but needs to exit at DISPATCH_LEVEL.
+*/
+_IRQL_raises_(DISPATCH_LEVEL)
+    VOID IrqlRaiseLevelExplicit_pass(void)
+{
+    KIRQL oldIRQL;
+    KeRaiseIrql(DISPATCH_LEVEL, &oldIRQL);
+    KeLowerIrql(oldIRQL);
+}


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [x] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [x] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.