### PR TITLE
IrqlFunctionNotAnnotated: codeql port of c28167

### DIFF
--- a/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.qhelp
+++ b/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.qhelp
@@ -1,0 +1,46 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+		The function changes the IRQL and does not restore the IRQL before it exits. It should be annotated to reflect the change or the IRQL should be restored.
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+			This warning indicates that the following conditions are true: 
+			1. The function changes the IRQL at which the driver is running. 
+			2. There is at least one path through a function that does not, by function exit, restore the IRQL to the original IRQL that the driver was running at function entry.
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			Function which potentially raises the IRQL level but is not annotated to reflect the change.
+		</p>
+		<sample language="c"> <![CDATA[
+		void fail1(PKIRQL oldIrql)
+		{
+
+			if (oldIrql == PASSIVE_LEVEL)
+			{
+				KeLowerIrql(*oldIrql);
+			}
+			else
+			{
+				KeRaiseIrql(DISPATCH_LEVEL, oldIrql); // Function exits at DISPATCH_LEVEL
+			}
+		}
+		}]]>
+		
+	</example>
+	<semmleNotes>
+		<p>
+		</p>
+	</semmleNotes>
+	<references>
+		<li>
+			<a href="https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28167-function-changes-irql-without-restore">
+				C28167
+			</a>
+		</li>
+	</references>
+</qhelp>

--- a/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.ql
+++ b/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.ql
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * @id cpp/drivers/irql-function-not-annotated
+ * @kind problem
+ * @name Irql Function Not Annotated
+ * @description The function changes the IRQL and does not restore the IRQL before it exits. It should be annotated to reflect the change or the IRQL should be restored.
+ * @platform Desktop
+ * @feature.area Multiple
+ * @impact Insecure Coding Practice
+ * @repro.text This warning occurs when an IRQL annotation on a function is required, but one doesn't exist.
+ * @owner.email: sdat@microsoft.com
+ * @opaqueid CQLD-C28167
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ * @scope domainspecific
+ * @query-version v1
+ */
+
+import cpp
+import drivers.libraries.Irql
+
+from
+  Function f, int irqlLevelEntry, int irqlLevelExit, ControlFlowNode exitCfn,
+  ControlFlowNode entryCfn
+where
+  not f instanceof IrqlChangesFunction and
+  exists(FunctionCall fc |
+    fc.getTarget() instanceof IrqlChangesFunction and fc.getEnclosingFunction() = f
+  ) and
+  exitCfn = f.getControlFlowScope() and
+  entryCfn = f.getBlock() and
+  irqlLevelEntry = getPotentialExitIrqlAtCfn(entryCfn) and
+  irqlLevelExit = getPotentialExitIrqlAtCfn(exitCfn) and
+  irqlLevelEntry != irqlLevelExit 
+select f, "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."

--- a/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.sarif
+++ b/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.sarif
@@ -1,0 +1,432 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+      {
+          "tool": {
+              "driver": {
+                  "name": "CodeQL",
+                  "organization": "GitHub",
+                  "semanticVersion": "2.19.3",
+                  "notifications": [
+                      {
+                          "id": "cpp/baseline/expected-extracted-files",
+                          "name": "cpp/baseline/expected-extracted-files",
+                          "shortDescription": {
+                              "text": "Expected extracted files"
+                          },
+                          "fullDescription": {
+                              "text": "Files appearing in the source archive that are expected to be extracted."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          },
+                          "properties": {
+                              "tags": [
+                                  "expected-extracted-files",
+                                  "telemetry"
+                              ]
+                          }
+                      },
+                      {
+                          "id": "cpp/extractor/summary",
+                          "name": "cpp/extractor/summary",
+                          "shortDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "fullDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          }
+                      }
+                  ],
+                  "rules": [
+                      {
+                          "id": "cpp/drivers/irql-function-not-annotated",
+                          "name": "cpp/drivers/irql-function-not-annotated",
+                          "shortDescription": {
+                              "text": "Irql Function Not Annotated"
+                          },
+                          "fullDescription": {
+                              "text": "The function changes the IRQL and does not restore the IRQL before it exits. It should be annotated to reflect the change or the IRQL should be restored."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true,
+                              "level": "warning"
+                          },
+                          "properties": {
+                              "tags": [
+                                  "correctness"
+                              ],
+                              "description": "The function changes the IRQL and does not restore the IRQL before it exits. It should be annotated to reflect the change or the IRQL should be restored.",
+                              "feature.area": "Multiple",
+                              "id": "cpp/drivers/irql-function-not-annotated",
+                              "impact": "Insecure Coding Practice",
+                              "kind": "problem",
+                              "name": "Irql Function Not Annotated",
+                              "opaqueid": "CQLD-TODO",
+                              "owner.email:": "sdat@microsoft.com",
+                              "platform": "Desktop",
+                              "precision": "medium",
+                              "problem.severity": "warning",
+                              "query-version": "v1",
+                              "repro.text": "",
+                              "scope": "domainspecific"
+                          }
+                      }
+                  ]
+              },
+              "extensions": [
+                  {
+                      "name": "microsoft/windows-drivers",
+                      "semanticVersion": "1.3.0+2a7c167ba9555b452f626258191b4709647a936f",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "name": "codeql/cpp-all",
+                      "semanticVersion": "3.1.0+d42788844f7ec0a6b9832140313cc2318e513987",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
+          "invocations": [
+              {
+                  "toolExecutionNotifications": [
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/driver_snippet.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 1
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.h",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 2
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 0
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "message": {
+                              "text": "Internal telemetry for the C++ extractor.\n\nNo action needed.",
+                              "markdown": "Internal telemetry for the C++ extractor.\n\nNo action needed."
+                          },
+                          "level": "note",
+                          "timeUtc": "2025-01-16T06:28:21.752771Z",
+                          "descriptor": {
+                              "id": "cpp/extractor/summary",
+                              "index": 1
+                          },
+                          "properties": {
+                              "attributes": {
+                                  "cache-hits": 0,
+                                  "cache-misses": 1,
+                                  "extractor-failures": 1,
+                                  "extractor-successes": 0,
+                                  "trap-caching": "disabled"
+                              },
+                              "visibility": {
+                                  "statusPage": false,
+                                  "telemetry": true
+                              }
+                          }
+                      }
+                  ],
+                  "executionSuccessful": true
+              }
+          ],
+          "artifacts": [
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/driver_snippet.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 1
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.h",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                  }
+              }
+          ],
+          "results": [
+              {
+                  "ruleId": "cpp/drivers/irql-function-not-annotated",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-function-not-annotated",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/fail_driver1.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 303,
+                                  "endColumn": 18
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "9f98ff813d1498bc:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              },
+              {
+                  "ruleId": "cpp/drivers/irql-function-not-annotated",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-function-not-annotated",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/fail_driver1.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 246,
+                                  "endColumn": 22
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "8eddd6a4558a2051:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              },
+              {
+                  "ruleId": "cpp/drivers/irql-function-not-annotated",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-function-not-annotated",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/driver_snippet.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 1
+                              },
+                              "region": {
+                                  "startLine": 13,
+                                  "startColumn": 6,
+                                  "endColumn": 11
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "9a255999974eed8:1",
+                      "primaryLocationStartColumnFingerprint": "5"
+                  }
+              },
+              {
+                  "ruleId": "cpp/drivers/irql-function-not-annotated",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-function-not-annotated",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/fail_driver1.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 285,
+                                  "endColumn": 12
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "b6acb5a643d7209f:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              },
+              {
+                  "ruleId": "cpp/drivers/irql-function-not-annotated",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-function-not-annotated",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Function potentially changes the IRQL without restoring it to the original level, however, the function is not annotated to reflect such a change."
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/fail_driver1.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 202,
+                                  "endColumn": 13
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "85d63309bc40267f:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              }
+          ],
+          "columnKind": "utf16CodeUnits",
+          "properties": {
+              "semmle.formatSpecifier": "sarifv2.1.0"
+          }
+      }
+  ]
+}

--- a/src/drivers/general/queries/IrqlFunctionNotAnnotated/driver_snippet.c
+++ b/src/drivers/general/queries/IrqlFunctionNotAnnotated/driver_snippet.c
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Macros to enable or disable a code section that may or may not conflict with this test.
+#define SET_DISPATCH 1
+
+// Template function. Not used for this test.
+void top_level_call()
+{
+}
+
+
+void fail1(PKIRQL oldIrql)
+{
+
+    if (oldIrql == PASSIVE_LEVEL)
+    {
+        KeLowerIrql(*oldIrql);
+    }
+    else
+    {
+        KeRaiseIrql(DISPATCH_LEVEL, oldIrql); // Function exits at DISPATCH_LEVEL
+    }
+}
+
+_IRQL_raises_(DISPATCH_LEVEL)
+void pass(PKIRQL oldIrql)
+{
+
+    if (oldIrql == PASSIVE_LEVEL)
+    {
+        KeLowerIrql(*oldIrql);
+    }
+    KeRaiseIrql(DISPATCH_LEVEL, oldIrql); // Function exits at DISPATCH_LEVEL
+}


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [x] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [x] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.