### PR TITLE
IrqlCancelRoutine: CodeQL port of c28144

### DIFF
--- a/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.qhelp
+++ b/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.qhelp
@@ -1,0 +1,40 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+		TODO overview
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+			TODO recommendation
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			The following example shows an incorrect use of IoReleaseCncelSpinLock within a cancel routine
+		</p>
+		<sample language="c"> <![CDATA[
+			IoReleaseCancelSpinLock(PASSIVE_LEVEL);
+		}]]>
+		</sample>
+		<p>
+			Correct use of IoReleaseCncelSpinLock within a cancel routine
+		</p>
+		<sample language="c"> <![CDATA[
+			IoReleaseCancelSpinLock(Irp->CancelIrql);
+		}]]>
+		</sample>
+	</example>
+	<semmleNotes>
+		<p>
+		</p>
+	</semmleNotes>
+	<references>
+		<li>
+			<a href="https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28144-cancelirql-should-be-current-irql">
+				C28144
+			</a>
+		</li>
+	</references>
+</qhelp>

--- a/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.qhelp
+++ b/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.qhelp
@@ -2,12 +2,14 @@
 <qhelp>
 	<overview>
 		<p>
-		TODO overview
+		Within a cancel routine, at the point of exit, the IRQL in Irp->CancelIrql should be the current IRQL.
 		</p>
 	</overview>
 	<recommendation>
 		<p>
-			TODO recommendation
+		When the driver's Cancel routine exits, the value of the Irp->CancelIrql member is not the current IRQL. 
+ 		Typically, this error occurs when the driver does not call IoReleaseCancelSpinLock with the IRQL that was supplied by 
+ 		the most recent call to IoAcquireCancelSpinLock.
 		</p>
 	</recommendation>
 	<example>

--- a/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.ql
+++ b/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.ql
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * @id cpp/drivers/irql-cancel-routine
+ * @kind problem
+ * @name Irql Cancel Routine
+ * @description Within a cancel routine, at the point of exit, the IRQL in Irp->CancelIrql should be the current IRQL.
+ * @platform Desktop
+ * @feature.area Multiple
+ * @impact Insecure Coding Practice
+ * @repro.text When the driver's Cancel routine exits, the value of the Irp->CancelIrql member is not the current IRQL. 
+ * Typically, this error occurs when the driver does not call IoReleaseCancelSpinLock with the IRQL that was supplied by 
+ * the most recent call to IoAcquireCancelSpinLock.
+ * @owner.email: sdat@microsoft.com
+ * @opaqueid CQLD-C28144
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ * @scope domainspecific
+ * @query-version v1
+ */
+
+import cpp
+import drivers.libraries.Irql
+
+from Function f, FunctionCall fc
+where
+  (
+    f.(RoleTypeFunction).getRoleTypeString().matches("DRIVER_CANCEL") or
+    f.(ImplicitRoleTypeFunction).getExpectedRoleTypeString().matches("DRIVER_CANCEL")
+  ) and
+  fc.getEnclosingFunction() = f and
+  fc.getTarget().getName() = "IoReleaseCancelSpinLock" and
+  (
+    not fc.getArgument(0).(PointerFieldAccess).getQualifier() = f.getParameter(1).getAnAccess() or
+    not fc.getArgument(0).(PointerFieldAccess).getTarget().getName() = "CancelIrql"
+  )
+select fc, "IoReleaseCancelSpinLock inside a cancel routine needs to be called with Irp->CancelIrql"

--- a/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.sarif
+++ b/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.sarif
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+      {
+          "tool": {
+              "driver": {
+                  "name": "CodeQL",
+                  "organization": "GitHub",
+                  "semanticVersion": "2.19.3",
+                  "notifications": [
+                      {
+                          "id": "cpp/baseline/expected-extracted-files",
+                          "name": "cpp/baseline/expected-extracted-files",
+                          "shortDescription": {
+                              "text": "Expected extracted files"
+                          },
+                          "fullDescription": {
+                              "text": "Files appearing in the source archive that are expected to be extracted."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          },
+                          "properties": {
+                              "tags": [
+                                  "expected-extracted-files",
+                                  "telemetry"
+                              ]
+                          }
+                      },
+                      {
+                          "id": "cpp/extractor/summary",
+                          "name": "cpp/extractor/summary",
+                          "shortDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "fullDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          }
+                      }
+                  ],
+                  "rules": [
+                      {
+                          "id": "cpp/drivers/irql-cancel-routine",
+                          "name": "cpp/drivers/irql-cancel-routine",
+                          "shortDescription": {
+                              "text": "Irql Cancel Routine"
+                          },
+                          "fullDescription": {
+                              "text": "Within a cancel routine, at the point of exit, the IRQL in Irp->CancelIrql should be the current IRQL."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true,
+                              "level": "warning"
+                          },
+                          "properties": {
+                              "tags": [
+                                  "correctness"
+                              ],
+                              "description": "Within a cancel routine, at the point of exit, the IRQL in Irp->CancelIrql should be the current IRQL.",
+                              "feature.area": "Multiple",
+                              "id": "cpp/drivers/irql-cancel-routine",
+                              "impact": "Insecure Coding Practice",
+                              "kind": "problem",
+                              "name": "Irql Cancel Routine",
+                              "opaqueid": "CQLD-C28144",
+                              "owner.email:": "sdat@microsoft.com",
+                              "platform": "Desktop",
+                              "precision": "medium",
+                              "problem.severity": "warning",
+                              "query-version": "v1",
+                              "repro.text": "When the driver's Cancel routine exits, the value of the Irp->CancelIrql member is not the current IRQL. \n Typically, this error occurs when the driver does not call IoReleaseCancelSpinLock with the IRQL that was supplied by \n the most recent call to IoAcquireCancelSpinLock.",
+                              "scope": "domainspecific"
+                          }
+                      }
+                  ]
+              },
+              "extensions": [
+                  {
+                      "name": "microsoft/windows-drivers",
+                      "semanticVersion": "1.3.0+2a7c167ba9555b452f626258191b4709647a936f",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "name": "codeql/cpp-all",
+                      "semanticVersion": "3.1.0+d42788844f7ec0a6b9832140313cc2318e513987",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
+          "invocations": [
+              {
+                  "toolExecutionNotifications": [
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/driver_snippet.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 1
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.h",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 2
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 0
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "message": {
+                              "text": "Internal telemetry for the C++ extractor.\n\nNo action needed.",
+                              "markdown": "Internal telemetry for the C++ extractor.\n\nNo action needed."
+                          },
+                          "level": "note",
+                          "timeUtc": "2025-01-17T07:55:40.432830800Z",
+                          "descriptor": {
+                              "id": "cpp/extractor/summary",
+                              "index": 1
+                          },
+                          "properties": {
+                              "attributes": {
+                                  "cache-hits": 0,
+                                  "cache-misses": 1,
+                                  "extractor-failures": 1,
+                                  "extractor-successes": 0,
+                                  "trap-caching": "disabled"
+                              },
+                              "visibility": {
+                                  "statusPage": false,
+                                  "telemetry": true
+                              }
+                          }
+                      }
+                  ],
+                  "executionSuccessful": true
+              }
+          ],
+          "artifacts": [
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/driver_snippet.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 1
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.h",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                  }
+              }
+          ],
+          "results": [
+              {
+                  "ruleId": "cpp/drivers/irql-cancel-routine",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/irql-cancel-routine",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "IoReleaseCancelSpinLock inside a cancel routine needs to be called with Irp->CancelIrql"
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/fail_driver1.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 207,
+                                  "startColumn": 5,
+                                  "endColumn": 28
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "cb9584c3c973d221:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              }
+          ],
+          "columnKind": "utf16CodeUnits",
+          "properties": {
+              "semmle.formatSpecifier": "sarifv2.1.0"
+          }
+      }
+  ]
+}

--- a/src/drivers/general/queries/IrqlCancelRoutine/driver_snippet.c
+++ b/src/drivers/general/queries/IrqlCancelRoutine/driver_snippet.c
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Macros to enable or disable a code section that may or may not conflict with this test.
+#define SET_DISPATCH 1
+// Template function. Not used for this test.
+void top_level_call()
+{
+}
+
+#define IRQL_CANCEL_CHECK

--- a/src/drivers/test/WDMTestTemplate/driver/fail_driver1.c
+++ b/src/drivers/test/WDMTestTemplate/driver/fail_driver1.c
@@ -190,12 +190,25 @@ DispatchCancel (
     PIRP Irp
     )
 {  
-    //Doesn't do anything
     UNREFERENCED_PARAMETER(DeviceObject);
-    UNREFERENCED_PARAMETER(Irp);
+	UNREFERENCED_PARAMETER(Irp);
     return STATUS_SUCCESS;
 }
 
+_Use_decl_annotations_
+VOID
+DriverCancel(
+    struct _DEVICE_OBJECT* DeviceObject,
+    struct _IRP* Irp
+) 
+{
+
+#ifdef IRQL_CANCEL_CHECK
+    IoReleaseCancelSpinLock(PASSIVE_LEVEL); // This is a failing case for IRQL check. C28144
+#else
+    IoReleaseCancelSpinLock(Irp->CancelIrql);
+#endif 
+}
 
 _Use_decl_annotations_
 NTSTATUS

--- a/src/drivers/test/WDMTestTemplate/driver/fail_driver1.h
+++ b/src/drivers/test/WDMTestTemplate/driver/fail_driver1.h
@@ -74,3 +74,5 @@ KSERVICE_ROUTINE InterruptServiceRoutine;
 IO_DPC_ROUTINE DpcForIsrRoutine;
 
 DRIVER_UNLOAD DriverUnload;
+
+DRIVER_CANCEL DriverCancel;


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [x] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [x] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.