### PR TITLE
Add APIs to ExtendedDeprecatedApis for Codeql port of c28727

### DIFF
--- a/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.ql
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.ql
@@ -72,6 +72,9 @@ predicate matchesBannedApi(string input) {
   or
   // Functions marked deprecated in C28750
   input = any(["lstrlen", "lstrlenA", "lstrlenW"])
+  or
+  // Functions marked deprecated in C28727
+  input = any(["_itow", "_ultow", "strtok", "swscanf", "wcstok"])
 }
 
 /** A deprecated API. */
@@ -448,6 +451,20 @@ class ExtendedDeprecatedCall extends Element {
         name.matches("lstrlenA") and replacement = "strlen"
         or
         name.matches("lstrlenW") and replacement = "wcslen"
+      )
+
+      or
+      // Functions marked deprecated in C28727
+      (
+        name.matches("_itow") and replacement = "None"
+        or
+        name.matches("_ultow") and replacement = "None"
+        or
+        name.matches("strtok") and replacement = "None"
+        or
+        name.matches("swscanf") and replacement = "None"
+        or
+        name.matches("wcstok") and replacement = "None"
       )
     )
   }


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [x] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [x] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.