### PR TITLE
StrictTypeMatch: Codeql port of c28139

### DIFF
--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
@@ -18,7 +18,7 @@
  		KeWaitForSingleObject(
 			&EventDone,
 			Executive,
-			KernelMode,
+			Executive,
 			FALSE,
 			NULL);
 		}]]>
@@ -30,7 +30,7 @@
 		KeWaitForSingleObject(
 			&EventDone,
 			Executive,
-			Executive,
+			KernelMode,
 			FALSE,
 			NULL);
 		}]]>

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
@@ -1,0 +1,41 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+		TODO overview
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+			TODO recommendation
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			TODO example
+		</p>
+		<sample language="c"> <![CDATA[
+		// Example code
+		}]]>
+		</sample>
+		<p>
+			TODO example 2
+		</p>
+		<sample language="c"> <![CDATA[
+				// Example code
+		}]]>
+		</sample>
+	</example>
+	<semmleNotes>
+		<p>
+			TODO notes
+		</p>
+	</semmleNotes>
+	<references>
+		<li>
+			<a href="example.com">
+				Example link
+			</a>
+		</li>
+	</references>
+</qhelp>

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.qhelp
@@ -2,39 +2,48 @@
 <qhelp>
 	<overview>
 		<p>
-		TODO overview
+		 The argument should exactly match the type
 		</p>
 	</overview>
 	<recommendation>
 		<p>
-			TODO recommendation
+			An enumerated value in a function call does not match the type specified for the parameter in the function declaration. This error can occur when parameters are mis-coded, missing, or out of order. Because C permits enumerated values to be used interchangeably, and to be used interchangeably with integer constants, it is not unusual to pass the wrong enumerated value to a function without recognizing the error.
 		</p>
 	</recommendation>
 	<example>
 		<p>
-			TODO example
+		The following code example elicits this warning.		
 		</p>
 		<sample language="c"> <![CDATA[
-		// Example code
+ 		KeWaitForSingleObject(
+			&EventDone,
+			Executive,
+			KernelMode,
+			FALSE,
+			NULL);
 		}]]>
 		</sample>
 		<p>
-			TODO example 2
+			The following code example avoids this warning.
 		</p>
 		<sample language="c"> <![CDATA[
-				// Example code
+		KeWaitForSingleObject(
+			&EventDone,
+			Executive,
+			Executive,
+			FALSE,
+			NULL);
 		}]]>
 		</sample>
 	</example>
 	<semmleNotes>
 		<p>
-			TODO notes
 		</p>
 	</semmleNotes>
 	<references>
 		<li>
-			<a href="example.com">
-				Example link
+			<a href="https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28139-argument-operand-should-exactly-match">
+				C28139
 			</a>
 		</li>
 	</references>

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /**
- * @id cpp/drivers/TODO
+ * @id cpp/drivers/strict-type-match
  * @kind problem
- * @name TODO
- * @description TODO
+ * @name Strict Type Match
+ * @description The argument should exactly match the type
  * @platform Desktop
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
  * @owner.email: sdat@microsoft.com
- * @opaqueid CQLD-TODO
+ * @opaqueid CQLD-C28139
  * @problem.severity warning
  * @precision medium
  * @tags correctness
@@ -26,6 +26,7 @@ where
   fc.getArgument(i) = eca and
   p = fc.getTarget().getParameter(i) and
   (
+    // check for pattern __drv_strictType(typename, mode) 
     if p instanceof SALParameter
     then
     exists(string enumType1, string enumType2 | 
@@ -52,6 +53,7 @@ where
       )
     )
     else
+    // non SAL parameter
       eca.getTarget().getDeclaringEnum().toString() !=
         fc.getTarget()
             .getADeclarationEntry()

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * @id cpp/drivers/TODO
+ * @kind problem
+ * @name TODO
+ * @description TODO
+ * @platform Desktop
+ * @feature.area Multiple
+ * @impact Insecure Coding Practice
+ * @repro.text
+ * @owner.email: sdat@microsoft.com
+ * @opaqueid CQLD-TODO
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ * @scope domainspecific
+ * @query-version v1
+ */
+
+import cpp
+import drivers.libraries.SAL
+
+from EnumConstantAccess eca, FunctionCall fc, Parameter p, int i
+where
+  fc.getArgument(i) = eca and
+  p = fc.getTarget().getParameter(i) and
+  (
+    if p instanceof SALParameter
+    then
+    exists(string enumType1, string enumType2 | 
+      enumType1 = eca.getTarget().getDeclaringEnum().toString() and
+      enumType2 =
+        p.(SALParameter)
+            .getAnnotation()
+            .getUnexpandedArgument(0)
+            .toString()
+            .splitAt("/", _)
+            .replaceAll("enum", "")
+            .trim() and
+      not enumType2.matches("__drv_%") and // exclude other SAL annotations
+      not exists(string allowedType |
+        allowedType =
+          p.(SALParameter)
+              .getAnnotation()
+              .getUnexpandedArgument(0)
+              .toString()
+              .splitAt("/", _)
+              .replaceAll("enum", "")
+              .trim() and
+        allowedType = enumType1
+      )
+    )
+    else
+      eca.getTarget().getDeclaringEnum().toString() !=
+        fc.getTarget()
+            .getADeclarationEntry()
+            .getParameterDeclarationEntry(i)
+            .getType()
+            .getUnderlyingType()
+            .toString()
+  )
+select eca,
+  "Enumerated value in a function call does not match the type specified for the parameter in the function declaration"

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.sarif
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.sarif
@@ -1,0 +1,199 @@
+{
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
+  "version" : "2.1.0",
+  "runs" : [ {
+    "tool" : {
+      "driver" : {
+        "name" : "CodeQL",
+        "organization" : "GitHub",
+        "semanticVersion" : "2.15.4",
+        "notifications" : [ {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "name" : "cpp/baseline/expected-extracted-files",
+          "shortDescription" : {
+            "text" : "Expected extracted files"
+          },
+          "fullDescription" : {
+            "text" : "Files appearing in the source archive that are expected to be extracted."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "expected-extracted-files", "telemetry" ]
+          }
+        } ],
+        "rules" : [ {
+          "id" : "cpp/drivers/TODO",
+          "name" : "cpp/drivers/TODO",
+          "shortDescription" : {
+            "text" : "TODO"
+          },
+          "fullDescription" : {
+            "text" : "TODO"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "correctness" ],
+            "description" : "TODO",
+            "feature.area" : "Multiple",
+            "id" : "cpp/drivers/TODO",
+            "impact" : "Insecure Coding Practice",
+            "kind" : "problem",
+            "name" : "TODO",
+            "opaqueid" : "CQLD-TODO",
+            "owner.email:" : "sdat@microsoft.com",
+            "platform" : "Desktop",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "query-version" : "v1",
+            "repro.text" : "",
+            "scope" : "domainspecific"
+          }
+        } ]
+      },
+      "extensions" : [ {
+        "name" : "microsoft/windows-drivers",
+        "semanticVersion" : "1.0.13+4cf80ade609037becb8999823de45e08bd818a20",
+        "locations" : [ {
+          "uri" : "file:///C:/codeql-home/WDDST/src/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      } ]
+    },
+    "invocations" : [ {
+      "toolExecutionNotifications" : [ {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/driver_snippet.c",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 1
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/fail_driver1.c",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 0
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "driver/fail_driver1.h",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 2
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "cpp/baseline/expected-extracted-files",
+          "index" : 0
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          }
+        }
+      } ],
+      "executionSuccessful" : true
+    } ],
+    "artifacts" : [ {
+      "location" : {
+        "uri" : "driver/fail_driver1.c",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 0
+      }
+    }, {
+      "location" : {
+        "uri" : "driver/driver_snippet.c",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 1
+      }
+    }, {
+      "location" : {
+        "uri" : "driver/fail_driver1.h",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 2
+      }
+    } ],
+    "results" : [ {
+      "ruleId" : "cpp/drivers/TODO",
+      "ruleIndex" : 0,
+      "rule" : {
+        "id" : "cpp/drivers/TODO",
+        "index" : 0
+      },
+      "message" : {
+        "text" : "TODO"
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "driver/fail_driver1.c",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 56,
+            "endColumn" : 12
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "60c6386a5ee58eb6:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    } ],
+    "columnKind" : "utf16CodeUnits",
+    "properties" : {
+      "semmle.formatSpecifier" : "sarifv2.1.0"
+    }
+  } ]
+}

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.sarif
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.sarif
@@ -1,199 +1,349 @@
 {
-  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
-  "version" : "2.1.0",
-  "runs" : [ {
-    "tool" : {
-      "driver" : {
-        "name" : "CodeQL",
-        "organization" : "GitHub",
-        "semanticVersion" : "2.15.4",
-        "notifications" : [ {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "name" : "cpp/baseline/expected-extracted-files",
-          "shortDescription" : {
-            "text" : "Expected extracted files"
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+      {
+          "tool": {
+              "driver": {
+                  "name": "CodeQL",
+                  "organization": "GitHub",
+                  "semanticVersion": "2.20.3",
+                  "notifications": [
+                      {
+                          "id": "cpp/baseline/expected-extracted-files",
+                          "name": "cpp/baseline/expected-extracted-files",
+                          "shortDescription": {
+                              "text": "Expected extracted files"
+                          },
+                          "fullDescription": {
+                              "text": "Files appearing in the source archive that are expected to be extracted."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          },
+                          "properties": {
+                              "tags": [
+                                  "expected-extracted-files",
+                                  "telemetry"
+                              ]
+                          }
+                      },
+                      {
+                          "id": "cpp/extractor/summary",
+                          "name": "cpp/extractor/summary",
+                          "shortDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "fullDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          }
+                      }
+                  ],
+                  "rules": [
+                      {
+                          "id": "cpp/drivers/strict-type-match",
+                          "name": "cpp/drivers/strict-type-match",
+                          "shortDescription": {
+                              "text": "Strict Type Match"
+                          },
+                          "fullDescription": {
+                              "text": "The argument should exactly match the type"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true,
+                              "level": "warning"
+                          },
+                          "properties": {
+                              "tags": [
+                                  "correctness"
+                              ],
+                              "description": "The argument should exactly match the type",
+                              "feature.area": "Multiple",
+                              "id": "cpp/drivers/strict-type-match",
+                              "impact": "Insecure Coding Practice",
+                              "kind": "problem",
+                              "name": "Strict Type Match",
+                              "opaqueid": "CQLD-C28139",
+                              "owner.email:": "sdat@microsoft.com",
+                              "platform": "Desktop",
+                              "precision": "medium",
+                              "problem.severity": "warning",
+                              "query-version": "v1",
+                              "repro.text": "",
+                              "scope": "domainspecific"
+                          }
+                      }
+                  ]
+              },
+              "extensions": [
+                  {
+                      "name": "microsoft/windows-drivers",
+                      "semanticVersion": "1.3.0+dc4daf4bb75e890961507d5741e47db56e86a58f",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "name": "codeql/cpp-all",
+                      "semanticVersion": "3.1.0+d42788844f7ec0a6b9832140313cc2318e513987",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              ]
           },
-          "fullDescription" : {
-            "text" : "Files appearing in the source archive that are expected to be extracted."
-          },
-          "defaultConfiguration" : {
-            "enabled" : true
-          },
-          "properties" : {
-            "tags" : [ "expected-extracted-files", "telemetry" ]
+          "invocations": [
+              {
+                  "toolExecutionNotifications": [
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/driver_snippet.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 0
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.h",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 1
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 2
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "message": {
+                              "text": "Internal telemetry for the C++ extractor.\n\nNo action needed.",
+                              "markdown": "Internal telemetry for the C++ extractor.\n\nNo action needed."
+                          },
+                          "level": "note",
+                          "timeUtc": "2025-02-07T05:23:49.561392100Z",
+                          "descriptor": {
+                              "id": "cpp/extractor/summary",
+                              "index": 1
+                          },
+                          "properties": {
+                              "attributes": {
+                                  "cache-hits": 0,
+                                  "cache-misses": 1,
+                                  "compilers": [
+                                      {
+                                          "program": "cl",
+                                          "version": "Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34436 for x64"
+                                      }
+                                  ],
+                                  "extractor-failures": 1,
+                                  "extractor-successes": 0,
+                                  "trap-caching": "disabled"
+                              },
+                              "visibility": {
+                                  "statusPage": false,
+                                  "telemetry": true
+                              }
+                          }
+                      }
+                  ],
+                  "executionSuccessful": true
+              }
+          ],
+          "artifacts": [
+              {
+                  "location": {
+                      "uri": "driver/driver_snippet.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.h",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 1
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                  }
+              }
+          ],
+          "results": [
+              {
+                  "ruleId": "cpp/drivers/strict-type-match",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/strict-type-match",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Enumerated value in a function call does not match the type specified for the parameter in the function declaration"
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/driver_snippet.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 24,
+                                  "startColumn": 9,
+                                  "endColumn": 18
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "7355117ca6f969b0:1",
+                      "primaryLocationStartColumnFingerprint": "0"
+                  }
+              },
+              {
+                  "ruleId": "cpp/drivers/strict-type-match",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/strict-type-match",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "Enumerated value in a function call does not match the type specified for the parameter in the function declaration"
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/driver_snippet.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 28,
+                                  "startColumn": 15,
+                                  "endColumn": 24
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "4a104594107a7d07:1",
+                      "primaryLocationStartColumnFingerprint": "10"
+                  }
+              }
+          ],
+          "columnKind": "utf16CodeUnits",
+          "properties": {
+              "semmle.formatSpecifier": "sarifv2.1.0"
           }
-        } ],
-        "rules" : [ {
-          "id" : "cpp/drivers/TODO",
-          "name" : "cpp/drivers/TODO",
-          "shortDescription" : {
-            "text" : "TODO"
-          },
-          "fullDescription" : {
-            "text" : "TODO"
-          },
-          "defaultConfiguration" : {
-            "enabled" : true,
-            "level" : "warning"
-          },
-          "properties" : {
-            "tags" : [ "correctness" ],
-            "description" : "TODO",
-            "feature.area" : "Multiple",
-            "id" : "cpp/drivers/TODO",
-            "impact" : "Insecure Coding Practice",
-            "kind" : "problem",
-            "name" : "TODO",
-            "opaqueid" : "CQLD-TODO",
-            "owner.email:" : "sdat@microsoft.com",
-            "platform" : "Desktop",
-            "precision" : "medium",
-            "problem.severity" : "warning",
-            "query-version" : "v1",
-            "repro.text" : "",
-            "scope" : "domainspecific"
-          }
-        } ]
-      },
-      "extensions" : [ {
-        "name" : "microsoft/windows-drivers",
-        "semanticVersion" : "1.0.13+4cf80ade609037becb8999823de45e08bd818a20",
-        "locations" : [ {
-          "uri" : "file:///C:/codeql-home/WDDST/src/",
-          "description" : {
-            "text" : "The QL pack root directory."
-          }
-        }, {
-          "uri" : "file:///C:/codeql-home/WDDST/src/qlpack.yml",
-          "description" : {
-            "text" : "The QL pack definition file."
-          }
-        } ]
-      } ]
-    },
-    "invocations" : [ {
-      "toolExecutionNotifications" : [ {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/driver_snippet.c",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 1
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
-        }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/fail_driver1.c",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 0
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
-        }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "driver/fail_driver1.h",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 2
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "cpp/baseline/expected-extracted-files",
-          "index" : 0
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          }
-        }
-      } ],
-      "executionSuccessful" : true
-    } ],
-    "artifacts" : [ {
-      "location" : {
-        "uri" : "driver/fail_driver1.c",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 0
       }
-    }, {
-      "location" : {
-        "uri" : "driver/driver_snippet.c",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 1
-      }
-    }, {
-      "location" : {
-        "uri" : "driver/fail_driver1.h",
-        "uriBaseId" : "%SRCROOT%",
-        "index" : 2
-      }
-    } ],
-    "results" : [ {
-      "ruleId" : "cpp/drivers/TODO",
-      "ruleIndex" : 0,
-      "rule" : {
-        "id" : "cpp/drivers/TODO",
-        "index" : 0
-      },
-      "message" : {
-        "text" : "TODO"
-      },
-      "locations" : [ {
-        "physicalLocation" : {
-          "artifactLocation" : {
-            "uri" : "driver/fail_driver1.c",
-            "uriBaseId" : "%SRCROOT%",
-            "index" : 0
-          },
-          "region" : {
-            "startLine" : 56,
-            "endColumn" : 12
-          }
-        }
-      } ],
-      "partialFingerprints" : {
-        "primaryLocationLineHash" : "60c6386a5ee58eb6:1",
-        "primaryLocationStartColumnFingerprint" : "0"
-      }
-    } ],
-    "columnKind" : "utf16CodeUnits",
-    "properties" : {
-      "semmle.formatSpecifier" : "sarifv2.1.0"
-    }
-  } ]
+  ]
 }

--- a/src/drivers/general/queries/StrictTypeMatch/driver_snippet.c
+++ b/src/drivers/general/queries/StrictTypeMatch/driver_snippet.c
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Macros to enable or disable a code section that may or may not conflict with this test.
+#define SET_DISPATCH 1
+
+// Template function. Not used for this test.
+void top_level_call()
+{
+}
+KEVENT EventDone;
+
+void test_func(
+    MODE WaitMode)
+{
+    UNREFERENCED_PARAMETER(WaitMode);
+};
+
+void bad_call()
+{
+    KeWaitForSingleObject(
+        &EventDone,
+        Executive,
+        Executive,
+        FALSE,
+        NULL);
+
+    test_func(Executive);
+}
+
+void good_call()
+{
+    KeWaitForSingleObject(
+        &EventDone,
+        Executive,
+        KernelMode,
+        FALSE,
+        NULL);
+    
+    test_func(KernelMode);
+
+}
+// TODO add tests for query

--- a/src/drivers/general/queries/StrictTypeMatch/driver_snippet.c
+++ b/src/drivers/general/queries/StrictTypeMatch/driver_snippet.c
@@ -40,4 +40,3 @@ void good_call()
     test_func(KernelMode);
 
 }
-// TODO add tests for query


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [x] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [x] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.