### PR TITLE
InvalidFunctionClassTypedef: Codeql port of c28268

### DIFF
--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.qhelp
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.qhelp
@@ -1,0 +1,49 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+	<overview>
+		<p>
+		The function class on the function does not match the function class on the typedef used here
+		</p>
+	</overview>
+	<recommendation>
+		<p>
+			This warning indicates that an annotation on a function class does not match the function type, as specified by the type declaration. This warning indicates an error in the annotations, not in the code that is being analyzed.
+		</p>
+	</recommendation>
+	<example>
+		<p>
+			TODO example
+		</p>
+		<sample language="c"> <![CDATA[
+	typedef __drv_functionClass(TEST_ROUTINE)
+    VOID
+    TEST_ROUTINE(
+		VOID);
+	typedef TEST_ROUTINE *PTEST_ROUTINE;
+
+    // declare function with above typedef
+	TEST_ROUTINE func2;
+
+	// define function, but with different function class which causes the warning
+	__drv_functionClass(TEST_ROUTINE2)
+		VOID func2(
+			VOID)
+	{
+		; // Don't need to do anything heres
+	}
+		}]]>
+		</sample>
+		
+	</example>
+	<semmleNotes>
+		<p>
+		</p>
+	</semmleNotes>
+	<references>
+		<li>
+			<a href="https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/28268-function-class-does-not-match-typedef">
+				C28268
+			</a>
+		</li>
+	</references>
+</qhelp>

--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.qhelp
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.qhelp
@@ -12,7 +12,7 @@
 	</recommendation>
 	<example>
 		<p>
-			TODO example
+			Example where typedef of one type is used to declare the function but typedef of a different type is used in the function definition inside __drv_functionClass
 		</p>
 		<sample language="c"> <![CDATA[
 	typedef __drv_functionClass(TEST_ROUTINE)

--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.ql
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.ql
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
+ * @id cpp/drivers/invalid-function-class-typedef
+ * @kind problem
+ * @name Invalid Function Class Typedef
+ * @description The function class on the function does not match the function class on the typedef used here
+ * @platform Desktop
+ * @feature.area Multiple
+ * @impact Insecure Coding Practice
+ * @repro.text
+ * @owner.email: sdat@microsoft.com
+ * @opaqueid CQLD-C28268
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ * @scope domainspecific
+ * @query-version v1
+ */
+
+import cpp
+import drivers.libraries.SAL
+
+class FunctionClassAnnotatedTypedef extends TypedefType {
+  FunctionClassAnnotation funcAnnotation;
+
+  FunctionClassAnnotatedTypedef() { funcAnnotation.getTypedefDeclarations() = this }
+
+  FunctionClassAnnotation getFuncClassAnnotation() { result = funcAnnotation }
+}
+
+class FunctionClassAnnotation extends SALAnnotation {
+  string annotationName;
+
+  FunctionClassAnnotation() {
+    this.getMacroName() = ["__drv_functionClass", "_Function_class_"] and
+    annotationName = this.getMacroName()
+  }
+}
+
+class AnnotatedFunction extends Function {
+  FunctionClassAnnotation funcClassAnnotation;
+
+  AnnotatedFunction() {
+    funcClassAnnotation.getMacroName() = ["__drv_functionClass", "_Function_class_"] and
+    exists(FunctionDeclarationEntry fde |
+      fde = this.getADeclarationEntry() and
+      funcClassAnnotation.getDeclarationEntry() = fde
+    )
+    or
+    exists(FunctionDeclarationEntry fde |
+      fde.getFunction() = this and
+      fde.getTypedefType().(FunctionClassAnnotatedTypedef).getFuncClassAnnotation() =
+        funcClassAnnotation
+    )
+  }
+
+  FunctionClassAnnotation getFuncClassAnnotation() { result = funcClassAnnotation }
+}
+
+from AnnotatedFunction af, string declTypedef, string funcClass
+where
+  declTypedef = af.getADeclarationEntry().getTypedefType().toString() and
+  funcClass = af.getFuncClassAnnotation().getUnexpandedArgument(0) and
+  declTypedef != funcClass
+select af,
+  "The function class " + funcClass + " on the function does not match the function class " +
+    declTypedef + " on the typedef used here"

--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.sarif
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.sarif
@@ -1,0 +1,318 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+      {
+          "tool": {
+              "driver": {
+                  "name": "CodeQL",
+                  "organization": "GitHub",
+                  "semanticVersion": "2.20.3",
+                  "notifications": [
+                      {
+                          "id": "cpp/baseline/expected-extracted-files",
+                          "name": "cpp/baseline/expected-extracted-files",
+                          "shortDescription": {
+                              "text": "Expected extracted files"
+                          },
+                          "fullDescription": {
+                              "text": "Files appearing in the source archive that are expected to be extracted."
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          },
+                          "properties": {
+                              "tags": [
+                                  "expected-extracted-files",
+                                  "telemetry"
+                              ]
+                          }
+                      },
+                      {
+                          "id": "cpp/extractor/summary",
+                          "name": "cpp/extractor/summary",
+                          "shortDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "fullDescription": {
+                              "text": "C++ extractor telemetry"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true
+                          }
+                      }
+                  ],
+                  "rules": [
+                      {
+                          "id": "cpp/drivers/invalid-function-class-typedef",
+                          "name": "cpp/drivers/invalid-function-class-typedef",
+                          "shortDescription": {
+                              "text": "Invalid Function Class Typedef"
+                          },
+                          "fullDescription": {
+                              "text": "The function class on the function does not match the function class on the typedef used here"
+                          },
+                          "defaultConfiguration": {
+                              "enabled": true,
+                              "level": "warning"
+                          },
+                          "properties": {
+                              "tags": [
+                                  "correctness"
+                              ],
+                              "description": "The function class on the function does not match the function class on the typedef used here",
+                              "feature.area": "Multiple",
+                              "id": "cpp/drivers/invalid-function-class-typedef",
+                              "impact": "Insecure Coding Practice",
+                              "kind": "problem",
+                              "name": "Invalid Function Class Typedef",
+                              "opaqueid": "CQLD-C28268",
+                              "owner.email:": "sdat@microsoft.com",
+                              "platform": "Desktop",
+                              "precision": "medium",
+                              "problem.severity": "warning",
+                              "query-version": "v1",
+                              "repro.text": "",
+                              "scope": "domainspecific"
+                          }
+                      }
+                  ]
+              },
+              "extensions": [
+                  {
+                      "name": "microsoft/windows-drivers",
+                      "semanticVersion": "1.3.0+aa5a9fcd1a748aa2ee27f86f4178133865ecbf34",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/codeql-home/WDDST/src/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  },
+                  {
+                      "name": "codeql/cpp-all",
+                      "semanticVersion": "3.1.0+d42788844f7ec0a6b9832140313cc2318e513987",
+                      "locations": [
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/",
+                              "description": {
+                                  "text": "The QL pack root directory."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackRoot"
+                                  ]
+                              }
+                          },
+                          {
+                              "uri": "file:///C:/Users/jronstadt/.codeql/packages/codeql/cpp-all/3.1.0/qlpack.yml",
+                              "description": {
+                                  "text": "The QL pack definition file."
+                              },
+                              "properties": {
+                                  "tags": [
+                                      "CodeQL/LocalPackDefinitionFile"
+                                  ]
+                              }
+                          }
+                      ]
+                  }
+              ]
+          },
+          "invocations": [
+              {
+                  "toolExecutionNotifications": [
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/driver_snippet.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 0
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.h",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 1
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "locations": [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {
+                                          "uri": "driver/fail_driver1.c",
+                                          "uriBaseId": "%SRCROOT%",
+                                          "index": 2
+                                      }
+                                  }
+                              }
+                          ],
+                          "message": {
+                              "text": ""
+                          },
+                          "level": "none",
+                          "descriptor": {
+                              "id": "cpp/baseline/expected-extracted-files",
+                              "index": 0
+                          },
+                          "properties": {
+                              "formattedMessage": {
+                                  "text": ""
+                              }
+                          }
+                      },
+                      {
+                          "message": {
+                              "text": "Internal telemetry for the C++ extractor.\n\nNo action needed.",
+                              "markdown": "Internal telemetry for the C++ extractor.\n\nNo action needed."
+                          },
+                          "level": "note",
+                          "timeUtc": "2025-02-07T08:51:20.768551900Z",
+                          "descriptor": {
+                              "id": "cpp/extractor/summary",
+                              "index": 1
+                          },
+                          "properties": {
+                              "attributes": {
+                                  "cache-hits": 0,
+                                  "cache-misses": 1,
+                                  "compilers": [
+                                      {
+                                          "program": "cl",
+                                          "version": "Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34436 for x64"
+                                      }
+                                  ],
+                                  "extractor-failures": 1,
+                                  "extractor-successes": 0,
+                                  "trap-caching": "disabled"
+                              },
+                              "visibility": {
+                                  "statusPage": false,
+                                  "telemetry": true
+                              }
+                          }
+                      }
+                  ],
+                  "executionSuccessful": true
+              }
+          ],
+          "artifacts": [
+              {
+                  "location": {
+                      "uri": "driver/driver_snippet.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.h",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 1
+                  }
+              },
+              {
+                  "location": {
+                      "uri": "driver/fail_driver1.c",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                  }
+              }
+          ],
+          "results": [
+              {
+                  "ruleId": "cpp/drivers/invalid-function-class-typedef",
+                  "ruleIndex": 0,
+                  "rule": {
+                      "id": "cpp/drivers/invalid-function-class-typedef",
+                      "index": 0
+                  },
+                  "message": {
+                      "text": "The function class TEST_ROUTINE2 on the function does not match the function class TEST_ROUTINE on the typedef used here"
+                  },
+                  "locations": [
+                      {
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": "driver/driver_snippet.c",
+                                  "uriBaseId": "%SRCROOT%",
+                                  "index": 0
+                              },
+                              "region": {
+                                  "startLine": 37,
+                                  "startColumn": 10,
+                                  "endColumn": 15
+                              }
+                          }
+                      }
+                  ],
+                  "partialFingerprints": {
+                      "primaryLocationLineHash": "b8db234dee1fec96:1",
+                      "primaryLocationStartColumnFingerprint": "5"
+                  }
+              }
+          ],
+          "columnKind": "utf16CodeUnits",
+          "properties": {
+              "semmle.formatSpecifier": "sarifv2.1.0"
+          }
+      }
+  ]
+}

--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/driver_snippet.c
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/driver_snippet.c
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Macros to enable or disable a code section that may or may not conflict with this test.
+#define SET_DISPATCH 1
+
+// Template function. Not used for this test.
+void top_level_call()
+{
+}
+
+typedef __drv_functionClass(TEST_ROUTINE)
+    VOID
+    TEST_ROUTINE(
+        VOID);
+
+typedef TEST_ROUTINE *PTEST_ROUTINE;
+
+typedef __drv_functionClass(TEST_ROUTINE2)
+    VOID
+    TEST_ROUTINE2(
+        VOID);
+
+typedef TEST_ROUTINE2 *PTEST_ROUTINE2;
+
+TEST_ROUTINE func1;
+TEST_ROUTINE func2;
+
+__drv_functionClass(TEST_ROUTINE)
+    VOID func1(
+        VOID)
+{
+    ; // Don't need to do anything heres
+}
+
+__drv_functionClass(TEST_ROUTINE2)
+    VOID func2(
+        VOID)
+{
+    ; // Don't need to do anything heres
+}


### PR DESCRIPTION
## Checklist for Pull Requests

- [ ] Description is filled out.
- [ ] Only one query or related query group is in this pull request.
- [ ] The version number on changed queries has been increased via the `@version` comment in the file header.
- [ ] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [ ] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [ ] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.