### PR TITLE
Map suppression names for irql-function-not-annotated

### DIFF
--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -110,6 +110,9 @@ abstract class CASuppression extends PreprocessorPragma {
     this.getRuleName() = any(["__WARNING_PROTOTYPE_MISMATCH", "28127"]) and
     result = "lgtm[cpp/drivers/routine-function-type-not-expected]"
     or
+    this.getRuleName() = any(["__WARNING_UNEXPECTED_IRQL_CHANGE", "28167"]) and
+    result = "lgtm[cpp/drivers/irql-function-not-annotated]"
+    or
     result = "lgtm[" + this.getRuleName() + "]"
   }
 }


### PR DESCRIPTION
As noted at https://github.com/github/codeql/issues/20611 the suppression query doesn't currently accept the warning code for query `irql-function-not-annotated`.

Two related pieces of feedback--

1. The help page at https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/static-tools-and-codeql?tabs=whcp%2Clatest#suppressing-codeql-results uses incorrect syntax `#pragma(suppress:the-rule-id-here)` -- should be `#pragma prefast(suppress:the-rule-id-here)` or `#pragma warning(suppress:the-rule-id-here)`

2. The regex used to recognise these pragmas is quite brittle; consider accepting spaces between `prefast` or `warning` and the parenthesis, so as to recognise e.g. `#pragma warning (suppress:the-rule-id-here)`

## Checklist for Pull Requests

- [x] Description is filled out.
- [x] Only one query or related query group is in this pull request.
- [ ] The version number on changed queries has been increased via the `@version` comment in the file header.
- [x] All unit tests have been run: ([Test README.md](src\drivers\test\README.md)).
- [x] Commands `codeql database create` and `codeql database analyze` have completed successfully.
- [ ] A .qhelp file has been added for any new queries or updated if changes have been made to an existing query.