### PR TITLE
Normalize copyright headers and emails for all queries+libraries

### DIFF
--- a/src/drivers/apps/queries/experimental/UnsafeCallInGlobalInit/UnsafeCallInGlobalInit.ql
+++ b/src/drivers/apps/queries/experimental/UnsafeCallInGlobalInit/UnsafeCallInGlobalInit.ql
@@ -14,7 +14,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28637
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/DriverAlertSuppression.ql
+++ b/src/drivers/general/DriverAlertSuppression.ql
@@ -1,8 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @name Driver alert suppression
  * @description Suppresses alerts in Windows Drivers based on Code Analysis syntax.
  * @kind alert-suppression
  * @id cpp/windows/drivers/driver-alert-suppression
+ * @owner.email sdat@microsoft.com
  * 
  * This query is a suppression query designed to identify existing PREFast-style suppressions
  * in Windows driver code and honor them through LGTM's suppression system.  It cannot be run

--- a/src/drivers/general/queries/AnnotationSyntax/AnnotationSyntax.ql
+++ b/src/drivers/general/queries/AnnotationSyntax/AnnotationSyntax.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Annotations
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28266
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/DefaultPoolTag/DefaultPoolTag.ql
+++ b/src/drivers/general/queries/DefaultPoolTag/DefaultPoolTag.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text The following code locations call a pool allocation function with one of the default tags (' mdW' or ' kdD').
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28147
  * @problem.severity warning
  * @precision high

--- a/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.ql
+++ b/src/drivers/general/queries/ExtendedDeprecatedApis/ExtendedDeprecatedApis.ql
@@ -10,7 +10,7 @@
  * @impact Attack Surface Reduction
  * @feature.area Multiple
  * @repro.text The following code locations contain calls to an unsafe, deprecated function or macro.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28719
  * @problem.severity warning
  * @precision high

--- a/src/drivers/general/queries/FloatHardwareStateProtection/FloatHardwareStateProtection.ql
+++ b/src/drivers/general/queries/FloatHardwareStateProtection/FloatHardwareStateProtection.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text This warning is only applicable in kernel mode. The driver is attempting to use a variable or constant of a float type when the code is not protected by KeSaveFloatingPointState and KeRestoreFloatingPointState, or EngSaveFloatingPointState and EngRestoreFloatingPointState.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28110
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/ImportantFunctionCallOptimizedOut/ImportantFunctionCallOptimizedOut.ql
+++ b/src/drivers/general/queries/ImportantFunctionCallOptimizedOut/ImportantFunctionCallOptimizedOut.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text The current function call might be optimized during compilation, which could make sensitive data stay in memory. Use the SecureZeroMemory or RtlSecureZeroMemory functions instead. A heuristic looks for identifier names that contain items such as "key" or "pass" to trigger this warning.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28625
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/ImproperNotOperatorOnZero/ImproperNotOperatorOnZero.ql
+++ b/src/drivers/general/queries/ImproperNotOperatorOnZero/ImproperNotOperatorOnZero.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text Returning a status value such as !TRUE is not the same as returning a status value that indicates failure.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28650
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.ql
+++ b/src/drivers/general/queries/InvalidFunctionClassTypedef/InvalidFunctionClassTypedef.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28268
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/InvalidFunctionPointerAnnotation/InvalidFunctionPointerAnnotation.ql
+++ b/src/drivers/general/queries/InvalidFunctionPointerAnnotation/InvalidFunctionPointerAnnotation.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28165
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlAnnotationIssue/IrqlAnnotationIssue.ql
+++ b/src/drivers/general/queries/IrqlAnnotationIssue/IrqlAnnotationIssue.ql
@@ -11,7 +11,7 @@
  * @repro.text This warning indicates that the Code Analysis tool cannot interpret the function annotation because the annotation is not
  *  coded correctly. As a result, the Code Analysis tool cannot determine the specified IRQL value. This warning can occur with any of
  *  the driver-specific annotations that mention an IRQL when the Code Analysis tool cannot evaluate the expression for the IRQL.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28153
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.ql
+++ b/src/drivers/general/queries/IrqlCancelRoutine/IrqlCancelRoutine.ql
@@ -11,7 +11,7 @@
  * @repro.text When the driver's Cancel routine exits, the value of the Irp->CancelIrql member is not the current IRQL. 
  * Typically, this error occurs when the driver does not call IoReleaseCancelSpinLock with the IRQL that was supplied by 
  * the most recent call to IoAcquireCancelSpinLock.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28144
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlFloatStateMismatch/IrqlFloatStateMismatch.ql
+++ b/src/drivers/general/queries/IrqlFloatStateMismatch/IrqlFloatStateMismatch.ql
@@ -10,7 +10,7 @@
  * @impact Insecure Coding Practice
  * @repro.text The IRQL at which the driver is executing when it restores a floating-point state is different than the IRQL at which it was executing when it saved the floating-point state.
  * Because the IRQL at which the driver runs determines how the floating-point state is saved, the driver must be executing at the same IRQL when it calls the functions to save and to restore the floating-point state.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28111
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.ql
+++ b/src/drivers/general/queries/IrqlFunctionNotAnnotated/IrqlFunctionNotAnnotated.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text This warning occurs when an IRQL annotation on a function is required, but one doesn't exist.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28167
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlIllegalValue/IrqlIllegalValue.ql
+++ b/src/drivers/general/queries/IrqlIllegalValue/IrqlIllegalValue.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28151
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlInconsistentWithRequired/IrqlInconsistentWithRequired.ql
+++ b/src/drivers/general/queries/IrqlInconsistentWithRequired/IrqlInconsistentWithRequired.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text An _IRQL_requires_same_ annotation specifies that the driver should be executing at a particular IRQL when the function completes, but there is at least one path in which the driver is executing at a different IRQL when the function completes.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28166
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.ql
+++ b/src/drivers/general/queries/IrqlLoweredImproperly/IrqlLoweredImproperly.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28141
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/MultipleFunctionClassAnnotations/MultipleFunctionClassAnnotations.ql
+++ b/src/drivers/general/queries/MultipleFunctionClassAnnotations/MultipleFunctionClassAnnotations.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text This warning can be generated when there is a chain of typedefs.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-c28177
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/NtstatusExplicitCast/NtstatusExplicitCast.ql
+++ b/src/drivers/general/queries/NtstatusExplicitCast/NtstatusExplicitCast.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text This warning indicates that an NTSTATUS value is being explicitly cast to a Boolean type. This is likely to give undesirable results. For example, the typical success value for NTSTATUS, STATUS_SUCCESS, is false when tested as a Boolean.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28714
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/NtstatusExplicitCast2/NtstatusExplicitCast2.ql
+++ b/src/drivers/general/queries/NtstatusExplicitCast2/NtstatusExplicitCast2.ql
@@ -10,6 +10,7 @@
  * @impact Insecure Coding Practice
  * @repro.text This warning indicates that a Boolean is being cast to NTSTATUS. This is likely to give undesirable results. For example, the typical failure value for functions that return a Boolean (FALSE) is a success status when tested as an NTSTATUS.
  * @opaqueid CQLD-C28715
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/general/queries/NtstatusExplicitCast3/NtstatusExplicitCast3.ql
+++ b/src/drivers/general/queries/NtstatusExplicitCast3/NtstatusExplicitCast3.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28716
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/NullCharacterPointerAssignment/NullCharacterPointerAssignment.ql
+++ b/src/drivers/general/queries/NullCharacterPointerAssignment/NullCharacterPointerAssignment.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28730
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/PointerVariableSize/PointerVariableSize.ql
+++ b/src/drivers/general/queries/PointerVariableSize/PointerVariableSize.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28132
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.ql
+++ b/src/drivers/general/queries/RoleTypeCorrectlyUsed/RoleTypeCorrectlyUsed.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-D0007
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/StaticInitializer/StaticInitializer.ql
+++ b/src/drivers/general/queries/StaticInitializer/StaticInitializer.ql
@@ -17,7 +17,7 @@
  * static initializer are not pointer-to-member-function.  If a
  * pointer-to-member-function is required, write a simple static
  * member function that wraps a call to the actual member function.
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28651
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
+++ b/src/drivers/general/queries/StrictTypeMatch/StrictTypeMatch.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28139
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/experimental/DefaultPoolTagExtended/DefaultPoolTagExtended.ql
+++ b/src/drivers/general/queries/experimental/DefaultPoolTagExtended/DefaultPoolTagExtended.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text The following code locations call a pool allocation function with one of the default tags (' mdW' or ' kdD').
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28147e
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/experimental/DriverIsolationRtlViolation/DriverIsolationRtlViolation.ql
+++ b/src/drivers/general/queries/experimental/DriverIsolationRtlViolation/DriverIsolationRtlViolation.ql
@@ -10,7 +10,7 @@
  * @platform Desktop
  * @feature.area Multiple
  * @impact Insecure Coding Practice
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-D0008
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/experimental/DriverIsolationZwViolation1/DriverIsolationZwViolation1.ql
+++ b/src/drivers/general/queries/experimental/DriverIsolationZwViolation1/DriverIsolationZwViolation1.ql
@@ -9,7 +9,7 @@
  * @platform Desktop
  * @feature.area Multiple
  * @impact Insecure Coding Practice
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-D0009
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/general/queries/experimental/DriverIsolationZwViolation2/DriverIsolationZwViolation2.ql
+++ b/src/drivers/general/queries/experimental/DriverIsolationZwViolation2/DriverIsolationZwViolation2.ql
@@ -9,7 +9,7 @@
  * @platform Desktop
  * @feature.area Multiple
  * @impact Insecure Coding Practice
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-D0010
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/kmdf/queries/FloatSafeExit/FloatSafeExit.ql
+++ b/src/drivers/kmdf/queries/FloatSafeExit/FloatSafeExit.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28162
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/kmdf/queries/FloatUnsafeExit/FloatUnsafeExit.ql
+++ b/src/drivers/kmdf/queries/FloatUnsafeExit/FloatUnsafeExit.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-C28161
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/kmdf/queries/experimental/DeviceInitApi/DeviceInitApi.ql
+++ b/src/drivers/kmdf/queries/experimental/DeviceInitApi/DeviceInitApi.ql
@@ -5,6 +5,7 @@
  * @description Calling a WDF init API on a WDFDEVICE_INIT structure after calling WdfDeviceCreate can cause system instability, as the framework takes ownership of the structure.
  * Partially ported from the Static Driver Verifier (SDV) rule DeviceInitAPI; see https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/kmdf-deviceinitapi for details.
  * @kind path-problem
+ * @owner.email sdat@microsoft.com
  * @problem.severity error
  * @precision medium
  * @id cpp/windows/wdk/kmdf/device-init-api

--- a/src/drivers/kmdf/queries/wfp/ConnectRedirectHandleCreation/ConnectRedirectMultipleCallsHandleCreation.ql
+++ b/src/drivers/kmdf/queries/wfp/ConnectRedirectHandleCreation/ConnectRedirectMultipleCallsHandleCreation.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function does not call FwpsRedirectHandleCreate0 or calls it multiple times and does not cache the handle.
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/connect-reirect-handle-creation
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision low
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/ConnectRedirectPendClassify/ConnectRedirectPendClassify.ql
+++ b/src/drivers/kmdf/queries/wfp/ConnectRedirectPendClassify/ConnectRedirectPendClassify.ql
@@ -10,6 +10,7 @@
  * @repro.text The following function does not FWP_ACTION_BLOCK and/or clear the FWPS_RIGHT_ACTION_WRITE flag before calling FwpsPendClassify0
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/connect-redirect-pend-classify
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision low
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/FlowLayerCalloutReturnsBlock/FlowLayerCalloutReturnsBlock.ql
+++ b/src/drivers/kmdf/queries/wfp/FlowLayerCalloutReturnsBlock/FlowLayerCalloutReturnsBlock.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function sets FWP_ACTION_BLOCK on a callout registered to ALE_FLOW_ESTABLISHED_LAYERS
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/flow-layer-returns-block
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision low
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/InlineConnectRedirect/InlineConnectRedirectCalloutShouldNotSetReauthorize.ql
+++ b/src/drivers/kmdf/queries/wfp/InlineConnectRedirect/InlineConnectRedirectCalloutShouldNotSetReauthorize.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function asks for reauthorization and is an inline callout this is a contract violation
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/inline-connect-redirect
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/OobStreamInjection/OobStreamInjectionReturnsBlock.ql
+++ b/src/drivers/kmdf/queries/wfp/OobStreamInjection/OobStreamInjectionReturnsBlock.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function does not correctly set an action type for stream injection OOB
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/oob-stream-injection
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/StreamCalloutsSetActionType/StreamCalloutsSetActionType.ql
+++ b/src/drivers/kmdf/queries/wfp/StreamCalloutsSetActionType/StreamCalloutsSetActionType.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function does not correctly set an action type for non-inspection Stream callouts
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/stream-callout-set-action-type
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/StreamInspectionCallViolation/StreamInspectionFunctionCallViolation.ql
+++ b/src/drivers/kmdf/queries/wfp/StreamInspectionCallViolation/StreamInspectionFunctionCallViolation.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function calls both FwpsStreamContinue and FwpsStreamInjectAsync
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/stream-inspection-call-violation
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/kmdf/queries/wfp/TransportLayerCannotInjectCloneDuringClassify/TransportLayerCannotInjectCloneDuringClassify.ql
+++ b/src/drivers/kmdf/queries/wfp/TransportLayerCannotInjectCloneDuringClassify/TransportLayerCannotInjectCloneDuringClassify.ql
@@ -8,6 +8,7 @@
  * @repro.text The following function does inject a clone at the transport layers
  * @kind problem
  * @id cpp/windows/wdk/kmdf/wfp/transport-layer-cannot-inject-clone-during-classify
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/src/drivers/libraries/DriverIsolation.qll
+++ b/src/drivers/libraries/DriverIsolation.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import cpp
 import semmle.code.cpp.dataflow.new.DataFlow
 import semmle.code.cpp.dataflow.new.TaintTracking

--- a/src/drivers/libraries/IrqlDebug.qll
+++ b/src/drivers/libraries/IrqlDebug.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import cpp
 import drivers.libraries.Irql
 

--- a/src/drivers/libraries/RoleTypes.qll
+++ b/src/drivers/libraries/RoleTypes.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import cpp
 import drivers.libraries.SAL
 // import drivers.libraries.Irql // TODO: add this back in 

--- a/src/drivers/libraries/Suppression.qll
+++ b/src/drivers/libraries/Suppression.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import cpp
 
 // Reference: https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170

--- a/src/drivers/libraries/wfp.qll
+++ b/src/drivers/libraries/wfp.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Provides classes for identifying and reasoning about Microsoft Windows Filtering Platform Callout
  * (WFP) Annotation

--- a/src/drivers/ndis/libraries/NdisDrivers.qll
+++ b/src/drivers/ndis/libraries/NdisDrivers.qll
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * This QL library defines classes and predicates for analyzing NDIS drivers.
  * It provides definitions for NDIS dispatch routines, callback routines, and role types.

--- a/src/drivers/storport/libraries/StorportDrivers.qll
+++ b/src/drivers/storport/libraries/StorportDrivers.qll
@@ -1,11 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * This QL library defines classes and predicates for analyzing NDIS drivers.
  * It provides definitions for NDIS dispatch routines, callback routines, and role types.
  * The library also includes a typedef for the standard NDIS callback routines.
  */
 
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+
 import cpp
 import drivers.libraries.SAL
 

--- a/src/drivers/test/TestTemplates/QueryTemplate/QueryTemplate.ql
+++ b/src/drivers/test/TestTemplates/QueryTemplate/QueryTemplate.ql
@@ -9,7 +9,7 @@
  * @feature.area Multiple
  * @impact Insecure Coding Practice
  * @repro.text
- * @owner.email: sdat@microsoft.com
+ * @owner.email sdat@microsoft.com
  * @opaqueid CQLD-TODO
  * @problem.severity warning
  * @precision medium

--- a/src/drivers/wdm/queries/InconsistentDispatchAnnotations.ql
+++ b/src/drivers/wdm/queries/InconsistentDispatchAnnotations.ql
@@ -8,6 +8,7 @@
  * @repro.text One or more WDM dispatch routines is incorrectly annotated.
  * @kind problem
  * @id cpp/windows/wdk/inconsistent-dispatch-annotation
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @query-version v1
  */

--- a/src/microsoft/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosure.ql
+++ b/src/microsoft/Likely Bugs/Boundary Violations/PaddingByteInformationDisclosure.ql
@@ -7,6 +7,7 @@
  * @description A newly allocated struct or class that is initialized member-by-member may
  *              leak information if it includes padding bytes.
  * @kind problem
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-200

--- a/src/microsoft/Likely Bugs/Conversion/BadOverflowGuard.ql
+++ b/src/microsoft/Likely Bugs/Conversion/BadOverflowGuard.ql
@@ -9,6 +9,7 @@
  *              argument types are smaller than 4 bytes. This is because the
  *              result of the addition is promoted to a 4 byte int.
  * @kind problem
+ * @owner.email sdat@microsoft.com
  * @problem.severity error
  * @tags security
  *       external/cwe/cwe-190

--- a/src/microsoft/Likely Bugs/Conversion/InfiniteLoop.ql
+++ b/src/microsoft/Likely Bugs/Conversion/InfiniteLoop.ql
@@ -7,6 +7,7 @@
  * @description Comparisons between types of different widths in a loop
  *              condition can cause the loop to fail to terminate.
  * @kind problem
+ * @owner.email sdat@microsoft.com
  * @problem.severity error
  * @tags reliability
  *       security

--- a/src/microsoft/Likely Bugs/Memory Management/UseAfterFree/ProbableUseAfterFree.ql
+++ b/src/microsoft/Likely Bugs/Memory Management/UseAfterFree/ProbableUseAfterFree.ql
@@ -6,6 +6,7 @@
  * @description An allocated memory block is used after it has been freed. Behavior in such cases is undefined and can cause memory corruption.
  * @kind problem
  * @id cpp/probable-use-after-free
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @tags reliability
  *       security

--- a/src/microsoft/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree.ql
+++ b/src/microsoft/Likely Bugs/Memory Management/UseAfterFree/UseAfterFree.ql
@@ -6,6 +6,7 @@
  * @description An allocated memory block is used after it has been freed. Behavior in such cases is undefined and can cause memory corruption.
  * @kind problem
  * @id cpp/use-after-free
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @tags reliability
  *       security

--- a/src/microsoft/Likely Bugs/UninitializedPtrField.ql
+++ b/src/microsoft/Likely Bugs/UninitializedPtrField.ql
@@ -7,6 +7,7 @@
  * @description A pointer field which was not initialized during or since class 
  *              construction will cause a null pointer dereference.
  * @kind problem
+ * @owner.email sdat@microsoft.com
  * @problem.severity warning
  * @tags security
  *       external/cwe/cwe-476

--- a/src/microsoft/Security/CWE/CWE-704/WcharCharConversionLimited.ql
+++ b/src/microsoft/Security/CWE/CWE-704/WcharCharConversionLimited.ql
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @name Cast from char* to wchar_t* (ignore PUCHAR casts)
  * @description Casting a byte string to a wide-character string is likely
@@ -6,6 +8,7 @@
  *              This query is a specilized version of `cpp/incorrect-string-type-conversion` that ignores casting to `PUCHAR`
  * @kind problem
  * @id cpp/incorrect-string-type-conversion-ignore-puchar-casts
+ * @owner.email sdat@microsoft.com
  * @problem.severity error
  * @security-severity 8.8
  * @precision high

--- a/src/microsoft/Security/Crytpography/HardcodedIVCNG.ql
+++ b/src/microsoft/Security/Crytpography/HardcodedIVCNG.ql
@@ -5,6 +5,7 @@
  * @description Finds usage of a static (hardcoded) IV. (CNG)
  * @kind problem
  * @id cpp/weak-crypto/cng/hardcoded-iv
+ * @owner.email sdat@microsoft.com
  * @problem.severity error
  * @precision high
  * @tags security


### PR DESCRIPTION
Just a quick standardization PR to make sure all our queries/libraries have our copyright header and that all emails are marked to go to SDAT rather than individual employees.